### PR TITLE
Updates to Expressive 0.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "roave/security-advisories": "dev-master",
-        "zendframework/zend-expressive": "^0.3"
+        "zendframework/zend-expressive": "^0.4"
     },
     "require-dev": {
         "composer/composer": ">=1.0.0-alpha10",

--- a/src/Action/HomePageAction.php
+++ b/src/Action/HomePageAction.php
@@ -15,7 +15,7 @@ class HomePageAction
 
     private $template;
 
-    public function __construct(Router\RouterInterface $router, Template\TemplateInterface $template = null)
+    public function __construct(Router\RouterInterface $router, Template\TemplateRendererInterface $template = null)
     {
         $this->router   = $router;
         $this->template = $template;
@@ -36,13 +36,13 @@ class HomePageAction
             $data['routerDocs'] = 'http://framework.zend.com/manual/current/en/modules/zend.mvc.routing.html';
         }
 
-        if ($this->template instanceof Template\Plates) {
+        if ($this->template instanceof Template\PlatesRenderer) {
             $data['templateName'] = 'Plates';
             $data['templateDocs'] = 'http://platesphp.com/';
-        } elseif ($this->template instanceof Template\Twig) {
+        } elseif ($this->template instanceof Template\TwigRenderer) {
             $data['templateName'] = 'Twig';
             $data['templateDocs'] = 'http://twig.sensiolabs.org/documentation';
-        } elseif ($this->template instanceof Template\ZendView) {
+        } elseif ($this->template instanceof Template\ZendViewRenderer) {
             $data['templateName'] = 'Zend View';
             $data['templateDocs'] = 'http://framework.zend.com/manual/current/en/modules/zend.view.quick-start.html';
         }

--- a/src/Action/HomePageFactory.php
+++ b/src/Action/HomePageFactory.php
@@ -4,14 +4,16 @@ namespace App\Action;
 
 use Interop\Container\ContainerInterface;
 use Zend\Expressive\Router\RouterInterface;
-use Zend\Expressive\Template\TemplateInterface;
+use Zend\Expressive\Template\TemplateRendererInterface;
 
 class HomePageFactory
 {
     public function __invoke(ContainerInterface $container)
     {
         $router   = $container->get(RouterInterface::class);
-        $template = ($container->has(TemplateInterface::class)) ? $container->get(TemplateInterface::class) : null;
+        $template = ($container->has(TemplateRendererInterface::class))
+            ? $container->get(TemplateRendererInterface::class)
+            : null;
 
         return new HomePageAction($router, $template);
     }

--- a/src/Composer/Resources/config/templates-plates.php
+++ b/src/Composer/Resources/config/templates-plates.php
@@ -6,8 +6,8 @@ return [
             'Zend\Expressive\FinalHandler' =>
                 Zend\Expressive\Container\TemplatedErrorHandlerFactory::class,
 
-            Zend\Expressive\Template\TemplateInterface::class =>
-                Zend\Expressive\Container\Template\PlatesFactory::class,
+            Zend\Expressive\Template\TemplateRendererInterface::class =>
+                Zend\Expressive\Container\Template\PlatesRendererFactory::class,
         ],
     ],
 

--- a/src/Composer/Resources/config/templates-twig.php
+++ b/src/Composer/Resources/config/templates-twig.php
@@ -6,8 +6,8 @@ return [
             'Zend\Expressive\FinalHandler' =>
                 Zend\Expressive\Container\TemplatedErrorHandlerFactory::class,
 
-            Zend\Expressive\Template\TemplateInterface::class =>
-                Zend\Expressive\Container\Template\TwigFactory::class,
+            Zend\Expressive\Template\TemplateRendererInterface::class =>
+                Zend\Expressive\Container\Template\TwigRendererFactory::class,
         ],
     ],
 

--- a/src/Composer/Resources/config/templates-zend-view.php
+++ b/src/Composer/Resources/config/templates-zend-view.php
@@ -6,8 +6,8 @@ return [
             'Zend\Expressive\FinalHandler' =>
                 Zend\Expressive\Container\TemplatedErrorHandlerFactory::class,
 
-            Zend\Expressive\Template\TemplateInterface::class =>
-                Zend\Expressive\Container\Template\ZendViewFactory::class,
+            Zend\Expressive\Template\TemplateRendererInterface::class =>
+                Zend\Expressive\Container\Template\ZendViewRendererFactory::class,
         ],
     ],
 

--- a/src/Composer/config.php
+++ b/src/Composer/config.php
@@ -25,7 +25,7 @@ return [
     'questions' => [
         'router' => [
             'question'               => 'Which router you want to use?',
-            'default'                => 1,
+            'default'                => 2,
             // TRUE: Must choose one / FALSE: May choose one or none of the above
             'required'               => true,
             // Enable custom package input

--- a/test/Action/HomePageFactoryTest.php
+++ b/test/Action/HomePageFactoryTest.php
@@ -6,7 +6,7 @@ use App\Action\HomePageAction;
 use App\Action\HomePageFactory;
 use Interop\Container\ContainerInterface;
 use Zend\Expressive\Router\RouterInterface;
-use Zend\Expressive\Template\TemplateInterface;
+use Zend\Expressive\Template\TemplateRendererInterface;
 
 class HomePageFactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -24,7 +24,7 @@ class HomePageFactoryTest extends \PHPUnit_Framework_TestCase
     public function testFactoryWithoutTemplate()
     {
         $factory = new HomePageFactory();
-        $this->container->has(TemplateInterface::class)->willReturn(false);
+        $this->container->has(TemplateRendererInterface::class)->willReturn(false);
 
         $this->assertTrue($factory instanceof HomePageFactory);
 
@@ -36,8 +36,10 @@ class HomePageFactoryTest extends \PHPUnit_Framework_TestCase
     public function testFactoryWithTemplate()
     {
         $factory = new HomePageFactory();
-        $this->container->has(TemplateInterface::class)->willReturn(true);
-        $this->container->get(TemplateInterface::class)->willReturn($this->prophesize(TemplateInterface::class));
+        $this->container->has(TemplateRendererInterface::class)->willReturn(true);
+        $this->container
+            ->get(TemplateRendererInterface::class)
+            ->willReturn($this->prophesize(TemplateRendererInterface::class));
 
         $this->assertTrue($factory instanceof HomePageFactory);
 


### PR DESCRIPTION
- Sets the default router to FastRoute.
- Updates the templates to refer to `TemplateRendererInterface`, and to use the `Renderer` suffix for concrete implementations.
- Updates the routers to refer to routers using the `Router` suffix.