### PR TITLE
Use zend-stdlib for autoload config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "roave/security-advisories": "dev-master",
         "zendframework/zend-expressive": "^0.5",
-        "zendframework/zend-stdlib": "^2.7"
+        "zendframework/zend-stdlib": "~2.4"
     },
     "require-dev": {
         "composer/composer": ">=1.0.0-alpha10",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "roave/security-advisories": "dev-master",
         "zendframework/zend-expressive": "^0.5",
-        "zendframework/zend-stdlib": "~2.4"
+        "zendframework/zend-stdlib": "~2.7"
     },
     "require-dev": {
         "composer/composer": ">=1.0.0-alpha10",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "roave/security-advisories": "dev-master",
-        "zendframework/zend-expressive": "^0.5"
+        "zendframework/zend-expressive": "^0.5",
+        "zendframework/zend-stdlib": "^2.7"
     },
     "require-dev": {
         "composer/composer": ">=1.0.0-alpha10",

--- a/config/config.php
+++ b/config/config.php
@@ -1,5 +1,8 @@
 <?php
 
+use Zend\Stdlib\ArrayUtils;
+use Zend\Stdlib\Glob;
+
 /**
  * Configuration files are loaded in a specific order. First ``global.php`` and afterwards ``local.php``. This way
  * local settings overwrite global settings.
@@ -20,8 +23,8 @@ if (is_file($cachedConfigFile)) {
     $config = json_decode(file_get_contents($cachedConfigFile), true);
 } else {
     // Load configuration from autoload path
-    foreach (glob('config/autoload/{{,*.}global,{,*.}local}.php', GLOB_BRACE) as $file) {
-        $config = array_replace_recursive($config, include $file);
+    foreach (Glob::glob('config/autoload/{{,*.}global,{,*.}local}.php', Glob::GLOB_BRACE) as $file) {
+        $config = ArrayUtils::merge($config, include $file);
     }
 
     // Cache config if enabled


### PR DESCRIPTION
As discussed here: zendframework/zend-expressive#150

It fixes auto loading configuration files. This happens when routes are split in different files.

I'm not sure if zend-stdlib should be made a dependency since it is already included in zend-expressive.