### PR TITLE
Remove composer source dev dependency

### DIFF
--- a/src/Composer/OptionalPackages.php
+++ b/src/Composer/OptionalPackages.php
@@ -158,7 +158,7 @@ class OptionalPackages
         $io->write("<info>Remove installer</info>");
         // Remove composer source
         unset(self::$composerDefinition['require-dev']['composer/composer']);
-        // Remove our data
+        // Remove installer data
         unset(self::$composerDefinition['extra']['optional-packages']);
         if (empty(self::$composerDefinition['extra'])) {
             unset(self::$composerDefinition['extra']);

--- a/src/Composer/OptionalPackages.php
+++ b/src/Composer/OptionalPackages.php
@@ -156,11 +156,14 @@ class OptionalPackages
 
         // House keeping
         $io->write("<info>Remove installer</info>");
+        // Remove composer source
+        unset(self::$composerDefinition['require-dev']['composer/composer']);
+        // Remove our data
         unset(self::$composerDefinition['extra']['optional-packages']);
         if (empty(self::$composerDefinition['extra'])) {
             unset(self::$composerDefinition['extra']);
         }
-
+        // Remove installer scripts, only need to do this once
         unset(self::$composerDefinition['scripts']['pre-update-cmd']);
         unset(self::$composerDefinition['scripts']['pre-install-cmd']);
         if (empty(self::$composerDefinition['scripts'])) {


### PR DESCRIPTION
The composer source is only needed for developing the installer so it can be removed.