### PR TITLE
Added ability to specify minimal install

### DIFF
--- a/src/Composer/OptionalPackages.php
+++ b/src/Composer/OptionalPackages.php
@@ -328,6 +328,15 @@ class OptionalPackages
         }
     }
 
+    /**
+     * Copy a file to its final destination in the skeleton.
+     *
+     * @param IOInterface $io
+     * @param string $projectRoot
+     * @param string $source Source file.
+     * @param string $target Destination.
+     * @param bool $force whether or not to copy over an existing file.
+     */
     private static function copyFile(IOInterface $io, $projectRoot, $source, $target, $force = false)
     {
         // Copy file
@@ -344,6 +353,12 @@ class OptionalPackages
         copy(__DIR__ . $source, $projectRoot . $target);
     }
 
+    /**
+     * Ask if the user would like a minimal install.
+     *
+     * @param IOInterface $io
+     * @return bool
+     */
     private static function requestMinimal(IOInterface $io)
     {
         $query = [

--- a/src/Composer/Resources/config/routes-minimal-aura-router.php
+++ b/src/Composer/Resources/config/routes-minimal-aura-router.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+    'dependencies' => [
+        'invokables' => [
+            Zend\Expressive\Router\RouterInterface::class => Zend\Expressive\Router\AuraRouter::class,
+        ],
+        // Map middleware -> factories here
+        'factories' => [
+        ],
+    ],
+
+    'routes' => [
+        // Example:
+        // [
+        //     'name' => 'home',
+        //     'path' => '/',
+        //     'middleware' => App\Action\HomePageAction::class,
+        //     'allowed_methods' => ['GET'],
+        // ],
+    ],
+];

--- a/src/Composer/Resources/config/routes-minimal-fast-route.php
+++ b/src/Composer/Resources/config/routes-minimal-fast-route.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+    'dependencies' => [
+        'invokables' => [
+            Zend\Expressive\Router\RouterInterface::class => Zend\Expressive\Router\FastRouteRouter::class,
+        ],
+        // Map middleware -> factories here
+        'factories' => [
+        ],
+    ],
+
+    'routes' => [
+        // Example:
+        // [
+        //     'name' => 'home',
+        //     'path' => '/',
+        //     'middleware' => App\Action\HomePageAction::class,
+        //     'allowed_methods' => ['GET'],
+        // ],
+    ],
+];

--- a/src/Composer/Resources/config/routes-minimal-zf2-router.php
+++ b/src/Composer/Resources/config/routes-minimal-zf2-router.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+    'dependencies' => [
+        'invokables' => [
+            Zend\Expressive\Router\RouterInterface::class => Zend\Expressive\Router\ZendRouter::class,
+        ],
+        // Map middleware -> factories here
+        'factories' => [
+        ],
+    ],
+
+    'routes' => [
+        // Example:
+        // [
+        //     'name' => 'home',
+        //     'path' => '/',
+        //     'middleware' => App\Action\HomePageAction::class,
+        //     'allowed_methods' => ['GET'],
+        // ],
+    ],
+];

--- a/src/Composer/config.php
+++ b/src/Composer/config.php
@@ -39,6 +39,10 @@ return [
                         // Copy source file to target: '<source>' => '<target>'
                         '/Resources/config/routes-aura-router.php' => '/config/autoload/routes.global.php',
                     ],
+                    'minimal-files' => [
+                        // Copy source file to target: '<source>' => '<target>'
+                        '/Resources/config/routes-minimal-aura-router.php' => '/config/autoload/routes.global.php',
+                    ],
                 ],
                 2 => [
                     'name'     => 'FastRoute',
@@ -48,6 +52,9 @@ return [
                     'copy-files' => [
                         '/Resources/config/routes-fast-route.php' => '/config/autoload/routes.global.php',
                     ],
+                    'minimal-files' => [
+                        '/Resources/config/routes-minimal-fast-route.php' => '/config/autoload/routes.global.php',
+                    ],
                 ],
                 3 => [
                     'name'     => 'Zend Router',
@@ -56,6 +63,9 @@ return [
                     ],
                     'copy-files' => [
                         '/Resources/config/routes-zf2-router.php' => '/config/autoload/routes.global.php',
+                    ],
+                    'minimal-files' => [
+                        '/Resources/config/routes-minimal-zf2-router.php' => '/config/autoload/routes.global.php',
                     ],
                 ],
             ],
@@ -76,6 +86,9 @@ return [
                     'copy-files' => [
                         '/Resources/config/container-aura-di.php' => '/config/container.php',
                     ],
+                    'minimal-files' => [
+                        '/Resources/config/container-aura-di.php' => '/config/container.php',
+                    ],
                 ],
                 2 => [
                     'name'     => 'Pimple-interop',
@@ -83,6 +96,9 @@ return [
                         'mouf/pimple-interop',
                     ],
                     'copy-files' => [
+                        '/Resources/config/container-pimple-interop.php' => '/config/container.php',
+                    ],
+                    'minimal-files' => [
                         '/Resources/config/container-pimple-interop.php' => '/config/container.php',
                     ],
                 ],
@@ -93,6 +109,9 @@ return [
                         'ocramius/proxy-manager',
                     ],
                     'copy-files' => [
+                        '/Resources/config/container-zend-servicemanager.php' => '/config/container.php',
+                    ],
+                    'minimal-files' => [
                         '/Resources/config/container-zend-servicemanager.php' => '/config/container.php',
                     ],
                 ],
@@ -117,6 +136,9 @@ return [
                         '/Resources/templates/plates-layout.phtml' => '/templates/layout/default.phtml',
                         '/Resources/templates/plates-home-page.phtml' => '/templates/app/home-page.phtml',
                     ],
+                    'minimal-files' => [
+                        '/Resources/config/templates-plates.php' => '/config/autoload/templates.global.php',
+                    ],
                 ],
                 2 => [
                     'name'     => 'Twig',
@@ -130,6 +152,9 @@ return [
                         '/Resources/templates/twig-layout.html.twig' => '/templates/layout/default.html.twig',
                         '/Resources/templates/twig-home-page.html.twig' => '/templates/app/home-page.html.twig',
                     ],
+                    'minimal-files' => [
+                        '/Resources/config/templates-twig.php' => '/config/autoload/templates.global.php',
+                    ],
                 ],
                 3 => [
                     'name'     => 'Zend View <comment>installs Zend ServiceManager</comment>',
@@ -142,6 +167,9 @@ return [
                         '/Resources/templates/zend-view-error.phtml' => '/templates/error/error.phtml',
                         '/Resources/templates/zend-view-layout.phtml' => '/templates/layout/default.phtml',
                         '/Resources/templates/zend-view-home-page.phtml' => '/templates/app/home-page.phtml',
+                    ],
+                    'minimal-files' => [
+                        '/Resources/config/templates-zend-view.php' => '/config/autoload/templates.global.php',
                     ],
                 ],
             ],
@@ -159,6 +187,9 @@ return [
                         'filp/whoops',
                     ],
                     'copy-files' => [
+                        '/Resources/config/error-handler-whoops.php' => '/config/autoload/errorhandler.local.php',
+                    ],
+                    'minimal-files' => [
                         '/Resources/config/error-handler-whoops.php' => '/config/autoload/errorhandler.local.php',
                     ],
                 ],


### PR DESCRIPTION
Asks before any questions whether or not to do a minimal installation.  If so, it uses a different set of files to copy ("minimal-files" in the configuration), and, when all questions have been answered and changes completed, removes the middleware files and public assets.

Provides a solution for #17.