### PR TITLE
Be more explicit about order of loading config files

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -4,8 +4,8 @@ use Zend\Stdlib\ArrayUtils;
 use Zend\Stdlib\Glob;
 
 /**
- * Configuration files are loaded in a specific order. First ``global.php`` and afterwards ``local.php``. This way
- * local settings overwrite global settings.
+ * Configuration files are loaded in a specific order. First ``global.php``, then ``*.global.php``.
+ * then ``local.php`` and finally ``*.local.php``. This way local settings overwrite global settings.
  *
  * The configuration can be cached. This can be done by setting ``config_cache_enabled`` to ``true``.
  *


### PR DESCRIPTION
With the current glob, there are four type of config file loaded, so the comment in `config.php` needs to show the order that they are all loaded.