### PR TITLE
Cache config to a PHP array

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -9,9 +9,6 @@ use Zend\Stdlib\Glob;
  *
  * The configuration can be cached. This can be done by setting ``config_cache_enabled`` to ``true``.
  *
- * The configuration is stored in json so it is not depended on 3rd party libraries. Feel free to use something else
- * like Zend\Config\Writer to write PHP arrays.
- *
  * Obviously, if you use closures in your config you can't cache it.
  */
 
@@ -20,7 +17,7 @@ $cachedConfigFile = 'data/cache/app_config.php';
 $config = [];
 if (is_file($cachedConfigFile)) {
     // Try to load the cached config
-    $config = json_decode(file_get_contents($cachedConfigFile), true);
+    $config = include $cachedConfigFile;
 } else {
     // Load configuration from autoload path
     foreach (Glob::glob('config/autoload/{{,*.}global,{,*.}local}.php', Glob::GLOB_BRACE) as $file) {
@@ -29,7 +26,7 @@ if (is_file($cachedConfigFile)) {
 
     // Cache config if enabled
     if (isset($config['config_cache_enabled']) && $config['config_cache_enabled'] === true) {
-        file_put_contents($cachedConfigFile, json_encode($config));
+        file_put_contents($cachedConfigFile, '<?php return ' . var_export($config, true) . ';');
     }
 }
 


### PR DESCRIPTION
Use var_export to write the merged config array to disk. This means that we can load the config back using a simple include and avoid a `json_decode()` call.