### PR TITLE
Lightweight module system - configuration manager

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -13,11 +13,11 @@ use Zend\Stdlib\Glob;
  * Obviously, if you use closures in your config you can't cache it.
  */
 
-$moduleManager = new ConfigLoader(
+$configManager = new ConfigLoader(
     Glob::glob('config/autoload/{{,*.}global,{,*.}local}.php', Glob::GLOB_BRACE),
     [
         ApplicationConfig::class
     ]
 );
 
-return $moduleManager->getMergedConfig();
+return $configManager->getMergedConfig();

--- a/config/config.php
+++ b/config/config.php
@@ -1,6 +1,7 @@
 <?php
 
-use Zend\Stdlib\ArrayUtils;
+use App\ApplicationConfig;
+use App\ConfigLoader;
 use Zend\Stdlib\Glob;
 
 /**
@@ -9,30 +10,14 @@ use Zend\Stdlib\Glob;
  *
  * The configuration can be cached. This can be done by setting ``config_cache_enabled`` to ``true``.
  *
- * The configuration is stored in json so it is not depended on 3rd party libraries. Feel free to use something else
- * like Zend\Config\Writer to write PHP arrays.
- *
  * Obviously, if you use closures in your config you can't cache it.
  */
 
-$cachedConfigFile = 'data/cache/app_config.php';
+$moduleManager = new ConfigLoader(
+    Glob::glob('config/autoload/{{,*.}global,{,*.}local}.php', Glob::GLOB_BRACE),
+    [
+        ApplicationConfig::class
+    ]
+);
 
-$config = [];
-if (is_file($cachedConfigFile)) {
-    // Try to load the cached config
-    $config = json_decode(file_get_contents($cachedConfigFile), true);
-} else {
-    // Load configuration from autoload path
-    foreach (Glob::glob('config/autoload/{{,*.}global,{,*.}local}.php', Glob::GLOB_BRACE) as $file) {
-        $config = ArrayUtils::merge($config, include $file);
-    }
-
-    // Cache config if enabled
-    if (isset($config['config_cache_enabled']) && $config['config_cache_enabled'] === true) {
-        file_put_contents($cachedConfigFile, json_encode($config));
-    }
-}
-
-// Return an ArrayObject so we can inject the config as a service in Aura.Di
-// and still use array checks like ``is_array``.
-return new ArrayObject($config, ArrayObject::ARRAY_AS_PROPS);
+return $moduleManager->getMergedConfig();

--- a/src/ApplicationConfig.php
+++ b/src/ApplicationConfig.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App;
+
+class ApplicationConfig implements ConfigProviderInterface
+{
+    public function getConfig()
+    {
+        return [
+            'routes' => [
+                [
+                    'name' => 'home',
+                    'path' => '/',
+                    'middleware' => \App\Action\HomePageAction::class,
+                    'allowed_methods' => ['GET'],
+                ],
+                [
+                    'name' => 'api.ping',
+                    'path' => '/api/ping',
+                    'middleware' => \App\Action\PingAction::class,
+                    'allowed_methods' => ['GET'],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -33,7 +33,6 @@ class ConfigLoader
         $config = [];
         // Load configuration from autoload path
         foreach ($configFiles as $file) {
-            echo $file, "\n";
             $config = ArrayUtils::merge($config, include $file);
         }
         return $config;

--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -1,0 +1,71 @@
+<?php
+namespace App;
+
+use ArrayObject;
+use RuntimeException;
+use Zend\Stdlib\ArrayUtils;
+
+class ConfigLoader
+{
+    /**
+     * @var ArrayObject
+     */
+    private $config;
+
+    private function loadConfigFromProviders(array $providers)
+    {
+        $config = [];
+        foreach ($providers as $providerClass) {
+            if (!class_exists($providerClass)) {
+                throw new RuntimeException("Cannot read config from $providerClass - class cannot be loaded.");
+            }
+            $provider = new $providerClass();
+            if (!$provider instanceof ConfigProviderInterface) {
+                throw new RuntimeException("Cannot read config from $providerClass - class does not implement ConfigProviderInterface");
+            }
+            $config = ArrayUtils::merge($config, $provider->getConfig());
+        }
+        return $config;
+    }
+
+    private function loadConfigFromFiles(array $configFiles)
+    {
+        $config = [];
+        // Load configuration from autoload path
+        foreach ($configFiles as $file) {
+            $config = ArrayUtils::merge($config, include $file);
+        }
+        return $config;
+    }
+
+    public function __construct(array $configFiles, array $providers, $cachedConfigFile = 'data/cache/app_config.php')
+    {
+        if (is_file($cachedConfigFile)) {
+            // Try to load the cached config
+            $this->config = json_decode(file_get_contents($cachedConfigFile), true);
+            return;
+        }
+
+        $config = ArrayUtils::merge(
+            $this->loadConfigFromProviders($providers),
+            $this->loadConfigFromFiles($configFiles)
+        );
+
+        // Cache config if enabled
+        if (isset($config['config_cache_enabled']) && $config['config_cache_enabled'] === true) {
+            file_put_contents($cachedConfigFile, json_encode($config));
+        }
+
+        // Return an ArrayObject so we can inject the config as a service in Aura.Di
+        // and still use array checks like ``is_array``.
+        $this->config = new ArrayObject($config, ArrayObject::ARRAY_AS_PROPS);
+    }
+
+    /**
+     * @return ArrayObject
+     */
+    public function getMergedConfig()
+    {
+        return $this->config;
+    }
+}

--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -33,6 +33,7 @@ class ConfigLoader
         $config = [];
         // Load configuration from autoload path
         foreach ($configFiles as $file) {
+            echo $file, "\n";
             $config = ArrayUtils::merge($config, include $file);
         }
         return $config;

--- a/src/ConfigProviderInterface.php
+++ b/src/ConfigProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App;
+
+use ArrayObject;
+
+interface ConfigProviderInterface
+{
+    /**
+     * @return array|ArrayObject
+     */
+    public function getConfig();
+}

--- a/test/ConfigLoaderTest.php
+++ b/test/ConfigLoaderTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AppTest;
+
+use App\ConfigLoader;
+use AppTest\Resources\BarConfigProvider;
+use AppTest\Resources\FooConfigProvider;
+use PHPUnit_Framework_TestCase;
+use Zend\Stdlib\Glob;
+
+class ConfigLoaderTest extends PHPUnit_Framework_TestCase
+{
+    public function testConfigLoaderMergesConfigFromProviders()
+    {
+        $loader = new ConfigLoader([], [FooConfigProvider::class, BarConfigProvider::class]);
+        $config = $loader->getMergedConfig();
+        $this->assertEquals(['foo' => 'bar', 'bar' => 'bat'], (array)$config);
+    }
+
+    public function testConfigLoaderMergesConfigFromFiles()
+    {
+        $loader = new ConfigLoader(Glob::glob('test/Resources/config/{{,*.}global,{,*.}local}.php', Glob::GLOB_BRACE), []);
+        $config = $loader->getMergedConfig();
+        $this->assertEquals(['fruit' => 'banana', 'vegetable' => 'potato'], (array)$config);
+    }
+}

--- a/test/Resources/BarConfigProvider.php
+++ b/test/Resources/BarConfigProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace AppTest\Resources;
+
+use App\ConfigProviderInterface;
+use ArrayObject;
+
+class BarConfigProvider implements ConfigProviderInterface
+{
+    /**
+     * @return array|ArrayObject
+     */
+    public function getConfig()
+    {
+        return ['bar' => 'bat'];
+    }
+}

--- a/test/Resources/FooConfigProvider.php
+++ b/test/Resources/FooConfigProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace AppTest\Resources;
+
+use App\ConfigProviderInterface;
+use ArrayObject;
+
+class FooConfigProvider implements ConfigProviderInterface
+{
+    /**
+     * @return array|ArrayObject
+     */
+    public function getConfig()
+    {
+        return ['foo' => 'bar'];
+    }
+}

--- a/test/Resources/config/extra.local.php
+++ b/test/Resources/config/extra.local.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'vegetable' => 'potato'
+];

--- a/test/Resources/config/main.global.php
+++ b/test/Resources/config/main.global.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'fruit' => 'banana'
+];


### PR DESCRIPTION
This is yet another attempt to bring basic modularity to `Zend\Expressive`. Compared to my previous idea (using full `ModuleManager` from ZF2), this one is far simpler and comes with no overhead. I made an assumption that most common use case for a module is to add configuration that can be merged with other configs.

Why bother? I've seen a few discussions about modules for Expressive around, but with no conclusion. On the other hand, anytime I'm trying to write something more complex with Expressive, I run into the same problem ("how to do modules") over and over again.

In this approach each package can be shipped with "config provider" - a class that looks like this:

```php
namespace App;

class ApplicationConfig implements ConfigProviderInterface
{
    public function getConfig()
    {
        return [
            'routes' => [
                [
                    'name' => 'home',
                    'path' => '/',
                    'middleware' => \App\Action\HomePageAction::class,
                    'allowed_methods' => ['GET'],
                ],
                [
                    'name' => 'api.ping',
                    'path' => '/api/ping',
                    'middleware' => \App\Action\PingAction::class,
                    'allowed_methods' => ['GET'],
                ],
            ],
        ];
    }
}
```

I created a new class (`ConfigLoader`) to order to aggregate and merge configuration. It is able to load PHP files (basically acts as `config/config.php` file in current version) and config provider classes. You create by it passing list of files as the first argument and list of config classes as the second:

```php
// new config/config.php
$configManager = new ConfigLoader(
    Glob::glob('config/autoload/{{,*.}global,{,*.}local}.php', Glob::GLOB_BRACE),
    [
        ApplicationConfig::class,
	BlogConfig::class,
	SomeOtherConfig::class,
    ]
);
```

After object is created you can get merged config:

```php
$config = $configManager->getMergedConfig();
return $config;
```

This mimics ZF2 system - you can "composer install" module and add its config class to the list. It comes with no overhead - configuration from config classes can be cached on production environment, in which case whole system requires adding only one class to bootstrap process.

In order to make it easier to understand, I submitted this code as a PR to skeleton application. If this is accepted (or at least there will be somebody interested in using it), I will ship it as a separate package.

So, what do you guys think about this?