### PR TITLE
Add zend-expressive-helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": "^5.5 || ^7.0",
         "roave/security-advisories": "dev-master",
         "zendframework/zend-expressive": "~1.0.0-dev@dev",
+        "zendframework/zend-expressive-helpers": "^1.0",
         "zendframework/zend-stdlib": "~2.7"
     },
     "require-dev": {

--- a/config/autoload/dependencies.global.php
+++ b/config/autoload/dependencies.global.php
@@ -1,4 +1,7 @@
 <?php
+use Zend\Expressive\Application;
+use Zend\Expressive\Container\ApplicationFactory;
+use Zend\Expressive\Helper;
 
 return [
     // Provides application-wide services.
@@ -10,10 +13,12 @@ return [
         // class name.
         'invokables' => [
             // Fully\Qualified\InterfaceName::class => Fully\Qualified\ClassName::class,
+            Helper\ServerUrlHelper::class => Helper\ServerUrlHelper::class,
         ],
         // Use 'factories' for services provided by callbacks/factory classes.
         'factories' => [
-            Zend\Expressive\Application::class => Zend\Expressive\Container\ApplicationFactory::class,
-        ]
-    ]
+            Application::class => ApplicationFactory::class,
+            Helper\UrlHelper::class => Helper\UrlHelperFactory::class,
+        ],
+    ],
 ];

--- a/config/autoload/middleware-pipeline.global.php
+++ b/config/autoload/middleware-pipeline.global.php
@@ -1,6 +1,12 @@
 <?php
+use Zend\Expressive\Helper;
 
 return [
+    'dependencies' => [
+        'factories' => [
+            Helper\ServerUrlMiddleware::class => Helper\ServerUrlMiddlewareFactory::class,
+        ]
+    ],
     // This can be used to seed pre- and/or post-routing middleware
     'middleware_pipeline' => [
         // An array of middleware to register prior to registration of the
@@ -13,6 +19,7 @@ return [
             //    'path'  => '/path/to/match',
             //    'error' => true,
             //],
+            [ 'middleware' => Helper\ServerUrlMiddleware::class ],
         ],
 
         // An array of middleware to register after registration of the

--- a/src/Composer/Resources/config/templates-zend-view.php
+++ b/src/Composer/Resources/config/templates-zend-view.php
@@ -2,27 +2,9 @@
 
 return [
     'dependencies' => [
-        /*
-         * Note: delegator_factories only work with zend-servicemanager.
-         *
-         * To get equivalent functionality with Pimple, add the following to your
-         * config/container.php file:
-         *
-         * $container->extend(Zend\Expressive\Application::class, function ($app, $container) {
-         *     $app->attachRouteResultObserver($container->get(Zend\Expressive\ZendView\UrlHelper::class));
-         *     return $app;
-         * });
-         */
-        'delegator_factories' => [
-            Zend\Expressive\Application::class => [
-                Zend\Expressive\ZendView\ApplicationUrlDelegatorFactory::class,
-            ],
-        ],
         'factories' => [
             'Zend\Expressive\FinalHandler' =>
                 Zend\Expressive\Container\TemplatedErrorHandlerFactory::class,
-
-            Zend\Expressive\ZendView\UrlHelper::class => Zend\Expressive\ZendView\UrlHelperFactory::class,
 
             Zend\Expressive\Template\TemplateRendererInterface::class =>
                 Zend\Expressive\ZendView\ZendViewRendererFactory::class,

--- a/src/Composer/config.php
+++ b/src/Composer/config.php
@@ -11,7 +11,7 @@ return [
         'zendframework/zend-expressive-platesrenderer'   => '^0.3',
         'zendframework/zend-expressive-twigrenderer'     => '^0.3.1',
         'zendframework/zend-expressive-zendrouter'       => '^0.3',
-        'zendframework/zend-expressive-zendviewrenderer' => '^0.3.1',
+        'zendframework/zend-expressive-zendviewrenderer' => '^0.4',
         'zendframework/zend-servicemanager'              => '^2.5',
     ],
 


### PR DESCRIPTION
This patch adds zend-expressive-helpers to the skeleton, which allows us to ship the `UrlHelper` and `ServerUrlHelper` by default.

It also means that the customizations for adding URL helper awareness to the zendviewrenderer configuration becomes obsolete, so this functionality was removed; as that functionality has not been in a release, the change is backwards compatible.