### PR TITLE
Use new twig config key

### DIFF
--- a/src/Composer/Resources/config/templates-twig.php
+++ b/src/Composer/Resources/config/templates-twig.php
@@ -12,14 +12,20 @@ return [
     ],
 
     'templates' => [
-        'cache_dir' => 'data/cache/twig',
-        'assets_url' => '/',
-        'assets_version' => null,
         'extension' => 'html.twig',
-        'paths' => [
+        'paths'     => [
             'app'    => ['templates/app'],
             'layout' => ['templates/layout'],
             'error'  => ['templates/error'],
-        ]
-    ]
+        ],
+    ],
+
+    'twig' => [
+        'cache_dir'      => 'data/cache/twig',
+        'assets_url'     => '/',
+        'assets_version' => null,
+        'extensions'     => [
+            // extension service names or instances
+        ],
+    ],
 ];


### PR DESCRIPTION
According to the changelog for [Expressive Twig Renderer 0.3.0](https://github.com/zendframework/zend-expressive-twigrenderer/releases/tag/0.3.0) it changed its config to:

```php
'templates' => [
   'extension' => 'file extension used by templates; defaults to html.twig',
   'paths' => [
       // namespace / path pairs
       //
       // Numeric namespaces imply the default/main namespace. Paths may be
       // strings or arrays of string paths to associate with the namespace.
   ],
],
'twig' => [
   'cache_dir' => 'path to cached templates',
   'assets_url' => 'base URL for assets',
   'assets_version' => 'base version for assets',
   'extensions' => [
       // extension service names or instances
   ],
],
```