### PR TITLE
Lightweight module system - configuration manager v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "roave/security-advisories": "dev-master",
         "zendframework/zend-expressive": "~1.0.0@rc || ^1.0",
         "zendframework/zend-expressive-helpers": "^1.2",
-        "zendframework/zend-stdlib": "~2.7"
+        "zendframework/zend-stdlib": "~2.7",
+        "mtymek/expressive-config-manager": "^0.2.0"
     },
     "require-dev": {
         "composer/composer": ">=1.0.0-alpha10",

--- a/config/config.php
+++ b/config/config.php
@@ -1,7 +1,7 @@
 <?php
 
 use Zend\Expressive\ConfigManager\ConfigManager;
-use Zend\Expressive\ConfigManager\GlobFileProvider;
+use Zend\Expressive\ConfigManager\PhpFileProvider;
 
 /**
  * Configuration files are loaded in a specific order. First ``global.php``, then ``*.global.php``.
@@ -14,9 +14,11 @@ use Zend\Expressive\ConfigManager\GlobFileProvider;
 
 $configManager = new ConfigManager(
     [
-        new GlobFileProvider('config/autoload/{{,*.}global,{,*.}local}.php'),
+        new PhpFileProvider('config/autoload/{{,*.}global,{,*.}local}.php'),
     ]
 );
 
-return $configManager->getMergedConfig();
+// Return an ArrayObject so we can inject the config as a service in Aura.Di
+// and still use array checks like ``is_array``.
+return new ArrayObject($configManager->getMergedConfig());
 

--- a/config/config.php
+++ b/config/config.php
@@ -1,7 +1,7 @@
 <?php
 
-use Zend\Stdlib\ArrayUtils;
-use Zend\Stdlib\Glob;
+use Zend\Expressive\ConfigManager\ConfigManager;
+use Zend\Expressive\ConfigManager\GlobFileProvider;
 
 /**
  * Configuration files are loaded in a specific order. First ``global.php``, then ``*.global.php``.
@@ -12,24 +12,11 @@ use Zend\Stdlib\Glob;
  * Obviously, if you use closures in your config you can't cache it.
  */
 
-$cachedConfigFile = 'data/cache/app_config.php';
+$configManager = new ConfigManager(
+    [
+        new GlobFileProvider('config/autoload/{{,*.}global,{,*.}local}.php'),
+    ]
+);
 
-$config = [];
-if (is_file($cachedConfigFile)) {
-    // Try to load the cached config
-    $config = include $cachedConfigFile;
-} else {
-    // Load configuration from autoload path
-    foreach (Glob::glob('config/autoload/{{,*.}global,{,*.}local}.php', Glob::GLOB_BRACE) as $file) {
-        $config = ArrayUtils::merge($config, include $file);
-    }
+return $configManager->getMergedConfig();
 
-    // Cache config if enabled
-    if (isset($config['config_cache_enabled']) && $config['config_cache_enabled'] === true) {
-        file_put_contents($cachedConfigFile, '<?php return ' . var_export($config, true) . ';');
-    }
-}
-
-// Return an ArrayObject so we can inject the config as a service in Aura.Di
-// and still use array checks like ``is_array``.
-return new ArrayObject($config, ArrayObject::ARRAY_AS_PROPS);


### PR DESCRIPTION
This PR replaces #26.

Another approach for adding modularity for Expressive apps. New syntax for building app config become simpler:

```php
$configManager = new ConfigManager(
    [
        new PhpFileProvider('config/autoload/{{,*.}global,{,*.}local}.php'),
        AppConfig::class,
    ]
);

return new ArrayObject($configManager->getMergedConfig());
```

`ConfigManager`'s workflow:
* if config cache file (`data/cache/app_config.php`) exists, then it is read and returned with no other processing (fast);
* if it is not available, then list of "config providers" passed to constructor is iterated, and config is merged (flexible)

"Config provider" is now an invokable class that resembles ZF2 module:

```php
class AppConfig
{
    public function __invoke()
    {
        // return array...
        return include __DIR__ . '/../config/module.config.php';
    }
}
```

Providers can also return a generator (for example, `PhpFileProvider` is using this feature). This gives us simple syntax (you pass all providers in a single array), and efficiency - if config cache exists, we don't have to call `glob`. 

This allows having similar application structure as ZF2 skeleton:

![image](https://cloud.githubusercontent.com/assets/777893/11664625/1da6db70-9de3-11e5-9150-8a7d4ca6d96e.png)

See [README](https://github.com/mtymek/expressive-config-manager#expressive-configuration-manager) for more details.