### PR TITLE
Update docs to pull @rc

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ removed.
 Start your new Expressive project with composer:
 
 ```bash
-$ composer create-project zendframework/zend-expressive-skeleton <project-path>
+$ composer create-project zendframework/zend-expressive-skeleton:^1.0@rc <project-path>
 ```
 
 After choosing and installing the packages you want, go to the


### PR DESCRIPTION
While this project sits at RC stage, you need to be more specific about which version to use. The .5 version (stable) is broken now due to changes in the other zend-expressive projects.