### PR TITLE
Updated to zend-expressive-helpers 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.0.0rc4 - TBD
+
+Fourth release candidate.
+
+### Added
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Updates to zendframework/zend-expressive-helpers `^1.2`.
+- Adds configuration for auto-registering the new `Zend\Expressive\Helper\UrlHelperMiddleware`
+  as pipeline middleware; this fixes an issue when using the zend-view renderer
+  with the `url()` helper whereby the `UrlHelper` was being registered as a
+  route result observer too late to receive the `RouteResult`.
+
 ## 1.0.0rc3 - 2015-12-07
 
 Third release candidate.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^5.5 || ^7.0",
         "roave/security-advisories": "dev-master",
         "zendframework/zend-expressive": "~1.0.0@rc || ^1.0",
-        "zendframework/zend-expressive-helpers": "^1.1",
+        "zendframework/zend-expressive-helpers": "^1.2",
         "zendframework/zend-stdlib": "~2.7"
     },
     "require-dev": {

--- a/config/autoload/middleware-pipeline.global.php
+++ b/config/autoload/middleware-pipeline.global.php
@@ -5,6 +5,7 @@ return [
     'dependencies' => [
         'factories' => [
             Helper\ServerUrlMiddleware::class => Helper\ServerUrlMiddlewareFactory::class,
+            Helper\UrlHelperMiddleware::class => Helper\UrlHelperMiddlewareFactory::class,
         ]
     ],
     // This can be used to seed pre- and/or post-routing middleware
@@ -20,6 +21,7 @@ return [
             //    'error' => true,
             //],
             [ 'middleware' => Helper\ServerUrlMiddleware::class ],
+            [ 'middleware' => Helper\UrlHelperMiddleware::class ],
         ],
 
         // An array of middleware to register after registration of the


### PR DESCRIPTION
- Updated version constraint in `composer.json`
- Added dependencies and pre_routing middleware-pipeline entries for `Zend\Expressive\Helper\UrlHelperMiddleware` to ensure the middleware is registered by default, ensuring the `UrlHelper` will be updated with the `RouteResult`.

This fixes issues reported and commented on in an [issue on Expressive](https://github.com/zendframework/zend-expressive/issues/186#issuecomment-162941737), ensuring the `UrlHelper` is properly seeded.