### PR TITLE
Update to new middleware array syntax

### DIFF
--- a/config/autoload/middleware-pipeline.global.php
+++ b/config/autoload/middleware-pipeline.global.php
@@ -15,13 +15,17 @@ return [
         'pre_routing' => [
             //[
             // Required:
-            //    'middleware' => 'Name of middleware service, or a callable',
+            //    'middleware' => 'Name or array of names of middleware services and/or callables',
             // Optional:
             //    'path'  => '/path/to/match',
             //    'error' => true,
             //],
-            [ 'middleware' => Helper\ServerUrlMiddleware::class ],
-            [ 'middleware' => Helper\UrlHelperMiddleware::class ],
+            [ 
+                'middleware' => [
+                    Helper\ServerUrlMiddleware::class,
+                    Helper\UrlHelperMiddleware::class
+                ],
+            ]
         ],
 
         // An array of middleware to register after registration of the


### PR DESCRIPTION
The expressive [cookbook](https://github.com/zendframework/zend-expressive/blob/master/doc/book/cookbook.md) indicates that we can use arrays of middleware here.