### PR TITLE
Added composer "serve" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,7 @@ After choosing and installing the packages you want, go to the
 `<project-path>` and start PHP's built-in web server to verify installation:
 
 ```bash
-$ php -S 0.0.0.0:8000 -t public/
+$ composer serve
 ```
+
+You can then browse to http://localhost:8080.

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         ],
         "cs": "phpcs",
         "cs-fix": "phpcbf",
+        "serve": "php -S 0.0.0.0:8080 -t public/",
         "test": "phpunit"
     }
 }


### PR DESCRIPTION
Executes `php -S 0.0.0.0:8080 -t public/`, starting up the built-in webserver from PHP:

```bash
$ composer serve
```