### PR TITLE
Add Pimple 3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "zendframework/zend-servicemanager": "^2.5",
         "ocramius/proxy-manager": "^1.0",
         "aura/di": "3.0.*@beta",
-        "mouf/pimple-interop": "^1.0"
+        "xtreamwayz/pimple-container-interop": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ExpressiveInstaller/Resources/config/container-pimple.php
+++ b/src/ExpressiveInstaller/Resources/config/container-pimple.php
@@ -1,29 +1,28 @@
 <?php
 
-use Interop\Container\Pimple\PimpleInterop;
+use Xtreamwayz\Pimple\Container;
 
 // Load configuration
 $config = require __DIR__ . '/config.php';
 
 // Build container
-$container = new PimpleInterop();
+$container = new Container();
 
 // Inject config
 $container['config'] = $config;
 
 // Inject factories
 foreach ($config['dependencies']['factories'] as $name => $object) {
-    $container[$name] = $container->share(function ($c) use ($object) {
+    $container[$name] = function ($c) use ($object) {
         $factory = new $object();
         return $factory($c);
-    });
+    };
 }
-
 // Inject invokables
 foreach ($config['dependencies']['invokables'] as $name => $object) {
-    $container[$name] = $container->share(function ($c) use ($object) {
+    $container[$name] = function ($c) use ($object) {
         return new $object();
-    });
+    };
 }
 
 return $container;

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -4,7 +4,7 @@ return [
     'packages' => [
         'aura/di'                                        => '3.0.*@beta',
         'filp/whoops'                                    => '^1.1',
-        'mouf/pimple-interop'                            => '^1.0',
+        'xtreamwayz/pimple-container-interop'            => '^1.0',
         'ocramius/proxy-manager'                         => '^1.0',
         'zendframework/zend-expressive-aurarouter'       => '^1.0',
         'zendframework/zend-expressive-fastroute'        => '^1.0',
@@ -91,15 +91,15 @@ return [
                     ],
                 ],
                 2 => [
-                    'name'     => 'Pimple-interop',
+                    'name'     => 'Pimple',
                     'packages' => [
-                        'mouf/pimple-interop',
+                        'xtreamwayz/pimple-container-interop',
                     ],
                     'copy-files' => [
-                        '/Resources/config/container-pimple-interop.php' => '/config/container.php',
+                        '/Resources/config/container-pimple.php' => '/config/container.php',
                     ],
                     'minimal-files' => [
-                        '/Resources/config/container-pimple-interop.php' => '/config/container.php',
+                        '/Resources/config/container-pimple.php' => '/config/container.php',
                     ],
                 ],
                 3 => [

--- a/test/ExpressiveInstallerTest/ContainersTest.php
+++ b/test/ExpressiveInstallerTest/ContainersTest.php
@@ -12,7 +12,7 @@ namespace ExpressiveInstallerTest;
 use Aura\Di\Container as AuraContainer;
 use ExpressiveInstaller\OptionalPackages;
 use Interop\Container\ContainerInterface;
-use Interop\Container\Pimple\PimpleInterop as PimpleInteropContainer;
+use Xtreamwayz\Pimple\Container as PimpleContainer;
 use ReflectionProperty;
 use Zend\Expressive;
 use Zend\ServiceManager\ServiceManager as ZendServiceManagerContainer;
@@ -68,8 +68,8 @@ class ContainersTest extends InstallerTestCase
         return [
             'aura-minimal'    => [1, 2, 'minimal-files', 404, AuraContainer::class],
             'aura-full'       => [1, 2, 'copy-files', 200, AuraContainer::class],
-            'pimple-minimal'  => [2, 2, 'minimal-files', 404, PimpleInteropContainer::class],
-            'pimple-full'     => [2, 2, 'copy-files', 200, PimpleInteropContainer::class],
+            'pimple-minimal'  => [2, 2, 'minimal-files', 404, PimpleContainer::class],
+            'pimple-full'     => [2, 2, 'copy-files', 200, PimpleContainer::class],
             'zend-sm-minimal' => [3, 2, 'minimal-files', 404, ZendServiceManagerContainer::class],
             'zend-sm-full'    => [3, 2, 'copy-files', 200, ZendServiceManagerContainer::class],
         ];


### PR DESCRIPTION
As discussed on IRC last night.

@weierophinney **NOTE**: Because of the new tests you have to make a choice if you want pimple 1 or 3 support. You can't have both since all dependencies are loaded once. This pull request has to be rebased and updated once the new tests are merged from #48.