### PR TITLE
factory sharing for pimple container

### DIFF
--- a/src/ExpressiveInstaller/Resources/config/container-pimple.php
+++ b/src/ExpressiveInstaller/Resources/config/container-pimple.php
@@ -13,9 +13,15 @@ $container['config'] = $config;
 
 // Inject factories
 foreach ($config['dependencies']['factories'] as $name => $object) {
-    $container[$name] = function ($c) use ($object) {
-        $factory = new $object();
-        return $factory($c);
+    $container[$name] = function ($c) use ($object, $name) {
+        if ($c->has($object)) {
+            $factory = $c->get($object);
+        } else {
+            $factory = new $object();
+            $c[$object] = $factory;
+        }
+
+        return $factory($c, $name);
     };
 }
 // Inject invokables


### PR DESCRIPTION
just an idea based on zend-servicemanager v3:
- stores the factory in the container
- allows reuse of the same factory (and same instance) for more than one service
- pass an extra parameter to the factory in order to make it possible to identify the requested service

Naming:
should we change $object to $factoryClass and $invokableClass to make it more explicit?