### PR TITLE
Set index.php as router in serve command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         ],
         "cs": "phpcs",
         "cs-fix": "phpcbf",
-        "serve": "php -S 0.0.0.0:8080 -t public/",
+        "serve": "php -S 0.0.0.0:8080 -t public/ public/index.php",
         "test": "phpunit"
     }
 }


### PR DESCRIPTION
Without this routes with extensions (etc .html, .css) don't routing by expressive.