### PR TITLE
Updated Apache asset rules

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,11 +6,6 @@ RewriteCond %{REQUEST_FILENAME} -l [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^.*$ - [NC,L]
 
-# Ignore static content and don't redirect it to the app.
-RewriteCond %{REQUEST_URI} ^(css|js|img|assets)/ [OR]
-RewriteCond %{REQUEST_FILENAME} \.(js|map|css|ico|gif|jpg|png|eot|svg|ttf|woff)$
-RewriteRule ^.*$ - [NC,L]
-
 # The following rewrites all other queries to index.php. The
 # condition ensures that if you are using Apache aliases to do
 # mass virtual hosting, the base path will be prepended to


### PR DESCRIPTION
The change in this patch is introduced after testing several debug bars.

The Apache `.htaccess` rules were updated to remove a section that was specifically matching web assets by extension (including CSS, JS, fonts, and most image formats). This rule was removed for the following reasons:

- The preceding rule would prevent it from triggering in most cases already, as it checks to see if the request is for a file on the filesystem, and, if so, returns it immediately.
- If the preceding rules failed, we likely want to serve the request through the web application (e.g., via Assetic, vfs, etc.). The rules as written would prevent that from happening.