### PR TITLE
Add Zend\ServiceManager v3 compatibility

### DIFF
--- a/src/ExpressiveInstaller/Resources/config/container-zend-servicemanager.php
+++ b/src/ExpressiveInstaller/Resources/config/container-zend-servicemanager.php
@@ -7,7 +7,7 @@ use Zend\ServiceManager\ServiceManager;
 $config = require __DIR__ . '/config.php';
 
 // Build container
-$container = new ServiceManager(new Config($config['dependencies']));
+$container = new ServiceManager((new Config($config['dependencies']))->toArray());
 
 // Inject config
 $container->setService('config', $config);

--- a/src/ExpressiveInstaller/Resources/config/container-zend-servicemanager.php
+++ b/src/ExpressiveInstaller/Resources/config/container-zend-servicemanager.php
@@ -7,7 +7,8 @@ use Zend\ServiceManager\ServiceManager;
 $config = require __DIR__ . '/config.php';
 
 // Build container
-$container = new ServiceManager((new Config($config['dependencies']))->toArray());
+$container = new ServiceManager();
+(new Config($config['dependencies']))->configureServiceManager($container);
 
 // Inject config
 $container->setService('config', $config);


### PR DESCRIPTION
Hello,
I wanted to give this skeleton a try. So I just did ``composer create-project zendframework/zend-expressive-skeleton`` but directly ran into the following error after install :

``Fatal error: Uncaught TypeError: Argument 1 passed to Zend\ServiceManager\ServiceManager::__construct() must be of the type array, object given``

I had chosen : FastRoute, Zend\ServiceManager and Twig as dependencies.

It appears that the installer made me download Zend\ServiceManager v3 as dependency. This PR fixes the config file to be compliant with v3, whose constructor expects an array to be injected.