### PR TITLE
Prepare for RC6

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ removed.
 Start your new Expressive project with composer:
 
 ```bash
-$ composer create-project zendframework/zend-expressive-skeleton <project-path>
+$ composer create-project --no-dev zendframework/zend-expressive-skeleton <project-path>
 ```
 
 > ### Release Candidates
@@ -39,8 +39,14 @@ $ composer create-project zendframework/zend-expressive-skeleton <project-path>
 > To install a release candidate, use the following:
 >
 > ```bash
-> $ composer create-project zendframework/zend-expressive-skeleton:^1.0@rc <project-path>
+> $ composer create-project --no-dev "zendframework/zend-expressive-skeleton:^1.0@rc" <project-path>
 > ```
+
+> ### Development requirements
+>
+> If you want Composer to install the development requirements defined by the
+> skeleton — specifically PHPUnit and PHP_CodeSniffer — run a `composer update`
+> after installing the skeleton.
 
 After choosing and installing the packages you want, go to the
 `<project-path>` and start PHP's built-in web server to verify installation:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^5.5 || ^7.0",
         "roave/security-advisories": "dev-master",
         "zendframework/zend-expressive": "~1.0.0@rc || ^1.0",
-        "zendframework/zend-expressive-helpers": "^1.3",
+        "zendframework/zend-expressive-helpers": "^2.0",
         "zendframework/zend-stdlib": "~2.7"
     },
     "require-dev": {

--- a/config/autoload/middleware-pipeline.global.php
+++ b/config/autoload/middleware-pipeline.global.php
@@ -1,4 +1,5 @@
 <?php
+use Zend\Expressive\Container\ApplicationFactory;
 use Zend\Expressive\Helper;
 
 return [
@@ -10,34 +11,58 @@ return [
     ],
     // This can be used to seed pre- and/or post-routing middleware
     'middleware_pipeline' => [
-        // An array of middleware to register prior to registration of the
-        // routing middleware
-        'pre_routing' => [
-            //[
-            // Required:
-            //    'middleware' => 'Name or array of names of middleware services and/or callables',
-            // Optional:
-            //    'path'  => '/path/to/match',
-            //    'error' => true,
-            //],
-            [
-                'middleware' => [
-                    Helper\ServerUrlMiddleware::class,
-                    Helper\UrlHelperMiddleware::class,
-                ],
+        // An array of middleware to register. Each item is of the following
+        // specification:
+        //
+        // [
+        //  Required:
+        //     'middleware' => 'Name or array of names of middleware services and/or callables',
+        //  Optional:
+        //     'path'     => '/path/to/match', // string; literal path prefix to match
+        //                                     // middleware will not execute
+        //                                     // if path does not match!
+        //     'error'    => true, // boolean; true for error middleware
+        //     'priority' => 1, // int; higher values == register early;
+        //                      // lower/negative == register last;
+        //                      // default is 1, if none is provided.
+        // ],
+        //
+        // While the ApplicationFactory ignores the keys associated with
+        // specifications, they can be used to allow merging related values
+        // defined in multiple configuration files/locations. This file defines
+        // some conventional keys for middleware to execute early, routing
+        // middleware, and error middleware.
+        'always' => [
+            'middleware' => [
+                // Add more middleware here that you want to execute on
+                // every request:
+                // - bootstrapping
+                // - pre-conditions
+                // - modifications to outgoing responses
+                Helper\ServerUrlMiddleware::class,
             ],
+            'priority' => 10000,
         ],
 
-        // An array of middleware to register after registration of the
-        // routing middleware
-        'post_routing' => [
-            //[
-            // Required:
-            //    'middleware' => 'Name of middleware service, or a callable',
-            // Optional:
-            //    'path'  => '/path/to/match',
-            //    'error' => true,
-            //],
+        'routing' => [
+            'middleware' => [
+                ApplicationFactory::ROUTING_MIDDLEWARE,
+                Helper\UrlHelperMiddleware::class,
+                // Add more middleware here that needs to introspect the routing
+                // results; this might include:
+                // - route-based authentication
+                // - route-based validation
+                // - etc.
+                ApplicationFactory::DISPATCH_MIDDLEWARE,
+            ],
+            'priority' => 1,
+        ],
+
+        'error' => [
+            'middleware' => [
+                // Add error middleware here.
+            ],
+            'priority' => -10000,
         ],
     ],
 ];

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -12,7 +12,7 @@ return [
         'zendframework/zend-expressive-twigrenderer'     => '^1.0',
         'zendframework/zend-expressive-zendrouter'       => '^1.0',
         'zendframework/zend-expressive-zendviewrenderer' => '^1.0',
-        'zendframework/zend-servicemanager'              => '^2.5',
+        'zendframework/zend-servicemanager'              => '^2.7.3 || ^3.0',
     ],
 
     'require-dev' => [


### PR DESCRIPTION
This patch provides a few changes to prepare for RC6:

- It updates the zend-servicemanager version constraint to `^2.7.3 || ^3.0`, to allow users to select the version they want to use. Configuration already works with either.
- It updates the zend-expressive-helpers dependency to `^2.0`, as that's the version compatible with zend-expressive RC6.
- It updates the `middleware_pipeline` to follow the changes in zend-expressive RC6, providing a list of middleware specifications with priority values, and creating the following specific definitions:
  - "always" is registered at priority 10000, and represents a pipeline of middleware that acts as either pre-conditions or post-routing handlers (e.g., CORS support, WWW-Authentication header injection, etc.).
  - "routing" is registered at priority 1, and defines a middleware pipeline containing the routing, UrlHelper, and dispatch middleware; any middleware that you might want to have intercept the results of routing could go between them.
  - "error" is registered at priority -1000, and defines a middleware pipeline for error handlers.

I've cloned and installed from the local branch with these changes, and all works as expected, with one exception: I discovered that an install installs the development dependencies *as defined prior to the installer script acting*. This means that *every* renderer and every router is installed at first. Running `composer update` immediately following an install corrects the situation, but it's not ideal. The situation likely pre-existed these changes, as I didn't change the installer scripts, and, as such, I'm not including a fix for that behavior at this time.