### PR TITLE
Update package requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "^2.3",
         "filp/whoops": "^1.1 || ^2.0",
-        "composer/composer": ">=1.0.0-alpha11",
+        "composer/composer": ">=1.0.0-beta1",
         "zendframework/zend-expressive-aurarouter": "^1.0",
         "zendframework/zend-expressive-fastroute": "^1.0",
         "zendframework/zend-expressive-zendrouter": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "roave/security-advisories": "dev-master",
-        "zendframework/zend-expressive": "~1.0.0@rc || ^1.0",
+        "zendframework/zend-expressive": "^1.0",
         "zendframework/zend-expressive-helpers": "^2.0",
         "zendframework/zend-stdlib": "~2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "zendframework/zend-expressive-platesrenderer": "^1.0",
         "zendframework/zend-expressive-twigrenderer": "^1.0",
         "zendframework/zend-expressive-zendviewrenderer": "^1.0",
-        "zendframework/zend-servicemanager": "^2.5",
+        "zendframework/zend-servicemanager": "^2.7.3 || ^3.0",
         "ocramius/proxy-manager": "^1.0",
         "aura/di": "3.0.*@beta",
         "xtreamwayz/pimple-container-interop": "^1.0"

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -3,7 +3,7 @@
 return [
     'packages' => [
         'aura/di'                                        => '3.0.*@beta',
-        'filp/whoops'                                    => '^1.1',
+        'filp/whoops'                                    => '^1.1 || ^2.0',
         'xtreamwayz/pimple-container-interop'            => '^1.0',
         'ocramius/proxy-manager'                         => '^1.0',
         'zendframework/zend-expressive-aurarouter'       => '^1.0',


### PR DESCRIPTION
The filp/whoops version was updated in composer.json to ``^1.1 || ^2.0`` but not in the config. This might have been the cause for some issues during installation like #71.

Also expressive is stable now, so we might as well go for stable versions only.