### PR TITLE
Add unlimited process-timeout setting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,9 @@
             "ExpressiveInstallerTest\\": "test/ExpressiveInstallerTest/"
         }
     },
+    "config": {
+        "process-timeout": 0
+    },
     "scripts": {
         "pre-install-cmd": "ExpressiveInstaller\\OptionalPackages::install",
         "pre-update-cmd": "ExpressiveInstaller\\OptionalPackages::install",


### PR DESCRIPTION
Hi, I got a below error.

```
$ composer serve
> php -S 0.0.0.0:8080 -t public/ public/index.php

  [Symfony\Component\Process\Exception\ProcessTimedOutException]
  The process "php -S 0.0.0.0:8080 -t public/ public/index.php" exceeded the timeout of 300 seconds.


serve [--dev] [--no-dev] [--] [<args>]...
```

The cause of error is process timed out in composer. (300 seconds in default)
Built-in server should not be timed out, IMO.

This PR add unlimited `process-timeout` setting and fix the issue.