### PR TITLE
Remove dumping the exceptions

### DIFF
--- a/src/ExpressiveInstaller/Resources/templates/plates-error.phtml
+++ b/src/ExpressiveInstaller/Resources/templates/plates-error.phtml
@@ -8,6 +8,4 @@
         You are looking for something that doesn't exist or may have moved. Check out one of the links on this page
         or head back to <a href="/">Home</a>.
     </p>
-<?php else : ?>
-    <pre><code><?=var_dump($this->e($error))?></code></pre>
 <?php endif; ?>

--- a/src/ExpressiveInstaller/Resources/templates/twig-error.html.twig
+++ b/src/ExpressiveInstaller/Resources/templates/twig-error.html.twig
@@ -11,7 +11,5 @@
             You are looking for something that doesn't exist or may have moved. Check out one of the links on this page
             or head back to <a href="{{ path('home') }}">Home</a>.
         </p>
-    {% else %}
-        <pre><code>{{ error }}</code></pre>
     {% endif %}
 {% endblock %}

--- a/src/ExpressiveInstaller/Resources/templates/zend-view-error.phtml
+++ b/src/ExpressiveInstaller/Resources/templates/zend-view-error.phtml
@@ -8,6 +8,4 @@
         You are looking for something that doesn't exist or may have moved. Check out one of the links on this page
         or head back to <a href="/">Home</a>.
     </p>
-<?php else : ?>
-    <pre><code><?php var_dump($this->error); ?></code></pre>
 <?php endif; ?>


### PR DESCRIPTION
closes #77 

Dumping the exception was never meant to make it into a stable release. Exceptions including stack traces can get pretty big. If you need something to debug your app, use tools like [whoops](https://zendframework.github.io/zend-expressive/features/error-handling/#whoops).