### PR TITLE
Allowing ProxyManager v2 installation

### DIFF
--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -5,7 +5,7 @@ return [
         'aura/di'                                        => '3.0.*@beta',
         'filp/whoops'                                    => '^1.1',
         'xtreamwayz/pimple-container-interop'            => '^1.0',
-        'ocramius/proxy-manager'                         => '^1.0',
+        'ocramius/proxy-manager'                         => '^1.0 || ^2.0',
         'zendframework/zend-expressive-aurarouter'       => '^1.0',
         'zendframework/zend-expressive-fastroute'        => '^1.0',
         'zendframework/zend-expressive-platesrenderer'   => '^1.0',


### PR DESCRIPTION
This PR mitigates #79 (does not solve it - only mitigates the problem, for now), by allowing `ocramius/proxy-manager:^2.0` installation

zendframework/zend-servicemanager#103 is also related, although not strictly required (changes only in the test-suite)