### PR TITLE
Use version constraint when adding a package

### DIFF
--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -319,8 +319,12 @@ class OptionalPackages
             $packageVersion
         ));
 
+        // Get the version constraint
+        $versionParser = new VersionParser();
+        $constraint = $versionParser->parseConstraints($packageVersion);
+
         // Create package link
-        $link = new Link('__root__', $packageName, null, 'requires', $packageVersion);
+        $link = new Link('__root__', $packageName, $constraint, 'requires', $packageVersion);
 
         // Add package to the root package and composer.json requirements
         if (in_array($packageName, self::$config['require-dev'])) {


### PR DESCRIPTION
The version was not properly added to the package, which causes composer to install the latest package even if it was higher than the required version.

fixes #79
fixes #71
fixes Ocramius/PSR7Session#47