### PR TITLE
Allow zend-stdlib 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
         "roave/security-advisories": "dev-master",
         "zendframework/zend-expressive": "^1.0",
         "zendframework/zend-expressive-helpers": "^2.0",
-        "zendframework/zend-stdlib": "~2.7"
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "^2.3",
         "filp/whoops": "^1.1 || ^2.0",
-        "composer/composer": ">=1.0.0-beta1",
+        "composer/composer": "^1.0",
         "zendframework/zend-expressive-aurarouter": "^1.0",
         "zendframework/zend-expressive-fastroute": "^1.0",
         "zendframework/zend-expressive-zendrouter": "^1.0",


### PR DESCRIPTION
Updates the version constraints to allow either the 2.7 or 3.0 series of zend-stdlib.