### PR TITLE
pimple protect factory

### DIFF
--- a/src/ExpressiveInstaller/Resources/config/container-pimple.php
+++ b/src/ExpressiveInstaller/Resources/config/container-pimple.php
@@ -18,7 +18,7 @@ foreach ($config['dependencies']['factories'] as $name => $object) {
             $factory = $c->get($object);
         } else {
             $factory = new $object();
-            $c[$object] = $factory;
+            $c[$object] = $c->protect($factory);
         }
 
         return $factory($c, $name);


### PR DESCRIPTION
storing object having a callable `__invoke()` method requires using Pimple::protect().... I (foolishly) forgot this in my previous commit.