### PR TITLE
Allow full install for `n || N || 2`

### DIFF
--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -432,7 +432,8 @@ class OptionalPackages
             $io->write("<error>Invalid answer</error>");
         }
 
-        return true;
+        // This should never be reached, defaults to default answer
+        return false;
     }
 
     /**

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -418,10 +418,21 @@ class OptionalPackages
             "  Make your selection <comment>(No)</comment>: ",
         ];
 
-        $answer = $io->ask($query, 'n');
+        while (true) {
+            $answer = $io->ask($query, 'n');
 
-        // Full install for `n`/`N`/`2`, anything else triggers a minimal install
-        return !(strtolower($answer) === 'n' || $answer === '2');
+            if (strtolower($answer) === 'n') {
+                return false;
+            }
+
+            if (strtolower($answer) === 'y') {
+                return true;
+            }
+
+            $io->write("<error>Invalid answer</error>");
+        }
+
+        return true;
     }
 
     /**

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -425,7 +425,7 @@ class OptionalPackages
         }
 
         // Full install for `n`/`N`/`2`, anything else triggers a minimal install
-        return !($answer === 'n' || $answer === 'N' || $answer === '2');
+        return !(strtolower($answer) === 'n' || $answer === '2');
     }
 
     /**

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -419,10 +419,6 @@ class OptionalPackages
         ];
 
         $answer = $io->ask($query, 'n');
-        if ($answer === 'n' || $answer === 'N' || $answer === 2) {
-            //
-            return false;
-        }
 
         // Full install for `n`/`N`/`2`, anything else triggers a minimal install
         return !(strtolower($answer) === 'n' || $answer === '2');

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -419,12 +419,13 @@ class OptionalPackages
         ];
 
         $answer = $io->ask($query, 'n');
-        if ($answer == 'n') {
-            // Nothing else to do!
+        if ($answer === 'n' || $answer === 'N' || $answer === 2) {
+            //
             return false;
         }
 
-        return true;
+        // Full install for `n`/`N`/`2`, anything else triggers a minimal install
+        return !($answer === 'n' || $answer === 'N' || $answer === '2');
     }
 
     /**


### PR DESCRIPTION
Allow full install for `n || N || 2`, anything else triggers a minimal install

It turns out mistakes can be made here (capslock, thinking the second answer can be chosen with `2`). Those answers are now valid as well.

closes #94