### PR TITLE
Force removal of whoops during the cleanup phase

### DIFF
--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -66,6 +66,7 @@ class OptionalPackages
 
     private static $devDependencies = [
         'composer/composer',
+        'filp/whoops',
         'zendframework/zend-expressive-aurarouter',
         'zendframework/zend-expressive-fastroute',
         'zendframework/zend-expressive-zendrouter',


### PR DESCRIPTION
Whoops should be removed from require-dev as well during the cleanup phase. If not the package will always be installed by composer even if an user answered with "none of the above".

Thanx to @Koopzington for reporting this in #99