### PR TITLE
Remove the proxy-manager as a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "zendframework/zend-expressive-twigrenderer": "^1.0",
         "zendframework/zend-expressive-zendviewrenderer": "^1.0",
         "zendframework/zend-servicemanager": "^2.7.3 || ^3.0",
-        "ocramius/proxy-manager": "^1.0",
         "aura/di": "^3.0",
         "xtreamwayz/pimple-container-interop": "^1.0"
     },

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -73,7 +73,6 @@ class OptionalPackages
         'zendframework/zend-expressive-twigrenderer',
         'zendframework/zend-expressive-zendviewrenderer',
         'zendframework/zend-servicemanager',
-        'ocramius/proxy-manager',
         'aura/di',
         'xtreamwayz/pimple-container-interop'
     ];

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -5,7 +5,6 @@ return [
         'aura/di'                                        => '^3.0',
         'filp/whoops'                                    => '^1.1 || ^2.0',
         'xtreamwayz/pimple-container-interop'            => '^1.0',
-        'ocramius/proxy-manager'                         => '^1.0 || ^2.0',
         'zendframework/zend-expressive-aurarouter'       => '^1.0',
         'zendframework/zend-expressive-fastroute'        => '^1.0',
         'zendframework/zend-expressive-platesrenderer'   => '^1.0',
@@ -106,7 +105,6 @@ return [
                     'name'     => 'Zend ServiceManager',
                     'packages' => [
                         'zendframework/zend-servicemanager',
-                        'ocramius/proxy-manager',
                     ],
                     'copy-files' => [
                         '/Resources/config/container-zend-servicemanager.php' => '/config/container.php',


### PR DESCRIPTION
It is only suggested by zend-servicemanager and not a required dependency. Therefor there is no need to add it.

Fixes #99

