### PR TITLE
Feature/enable zf development mode just like in ZendSkeletonApp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
+        "zfcampus/zf-development-mode": "^3.0",
         "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "^2.3",
         "filp/whoops": "^1.1 || ^2.0",
@@ -53,7 +54,11 @@
     },
     "scripts": {
         "pre-install-cmd": "ExpressiveInstaller\\OptionalPackages::install",
-        "pre-update-cmd": "ExpressiveInstaller\\OptionalPackages::install",
+        "pre-update-cmd": "ExpressiveInstaller\\OptionalPackages::install",        
+        "post-create-project-cmd": ["@development-enable"],
+        "development-disable": "zf-development-mode disable",
+        "development-enable": "zf-development-mode enable",
+        "development-status": "zf-development-mode status",
         "check": [
             "@cs",
             "@test"

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+development.config.php

--- a/config/config.php
+++ b/config/config.php
@@ -24,6 +24,11 @@ if (is_file($cachedConfigFile)) {
         $config = ArrayUtils::merge($config, include $file);
     }
 
+    // Development mode enabled
+    if (file_exists(__DIR__ . '/../config/development.config.php')) {
+        $config = ArrayUtils::merge($config, require __DIR__ . '/../config/development.config.php');
+    }
+
     // Cache config if enabled
     if (isset($config['config_cache_enabled']) && $config['config_cache_enabled'] === true) {
         file_put_contents($cachedConfigFile, '<?php return ' . var_export($config, true) . ';');

--- a/config/development.config.php.dist
+++ b/config/development.config.php.dist
@@ -1,0 +1,26 @@
+<?php
+
+use Zend\Expressive\Container;
+
+return [
+    'debug' => true,
+    'config_cache_enabled' => false,
+    
+    // Whoops error template handler
+    'dependencies' => [
+        'invokables'    => [
+            'Zend\Expressive\Whoops'            => Whoops\Run::class,
+            'Zend\Expressive\WhoopsPageHandler' => Whoops\Handler\PrettyPageHandler::class,
+        ],
+        'factories'     => [
+            'Zend\Expressive\FinalHandler' => Container\WhoopsErrorHandlerFactory::class
+        ]
+    ],
+    'whoops' => [
+        'json_exceptions' => [
+            'display'    => true,
+            'show_trace' => true,
+            'ajax_only'  => true,
+        ]
+    ]
+];


### PR DESCRIPTION
Based on my suggestion in https://github.com/zendframework/zend-expressive-skeleton/issues/104

Following changes are:
-  updated composer.json with zfcampus/zf-development-mode and scripts
- added development.config.php.dist file (including .gitignore)
- updated the merged configuration if development-mode is enabled.
