### PR TITLE
Refactor and improve tests

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,3 @@
+coverage_clover: clover.xml
+json_path: coveralls-upload.json
+src_dir: src

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,2 @@
 coverage_clover: clover.xml
 json_path: coveralls-upload.json
-src_dir: src

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .idea
 composer.phar
 composer.lock
+
+clover.xml
+coveralls-upload.json
 phpunit.xml
 vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,21 +20,15 @@ matrix:
         - DEPS=lowest
     - php: 5.6
       env:
-        - DEPS=locked
-        - TEST_COVERAGE=true
-    - php: 5.6
-      env:
         - DEPS=latest
+        - TEST_COVERAGE=true
     - php: 7
       env:
         - DEPS=lowest
     - php: 7
       env:
-        - DEPS=locked
-        - CHECK_CS=true
-    - php: 7
-      env:
         - DEPS=latest
+        - CHECK_CS=true
     - php: hhvm
   allow_failures:
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ matrix:
   fast_finish: true
   include:
     - php: 5.5
+      env:
+        - DEPS=lowest
+    - php: 5.5
+      env:
+        - DEPS=latest
     - php: 5.6
       env:
         - DEPS=lowest

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ env:
   global:
     - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs --no-scripts"
 
+notifications:
+  irc: "irc.freenode.org#zftalk.dev"
+  email: false
+
 matrix:
   fast_finish: true
   include:
@@ -51,6 +55,3 @@ script:
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer upload-coverage ; fi
-
-notifications:
-  email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,6 @@ matrix:
       env:
         - DEPS=latest
     - php: hhvm
-      env:
-        - DEPS=lowest
-    - php: hhvm
-      env:
-        - DEPS=locked
-    - php: hhvm
-      env:
-        - DEPS=latest
   allow_failures:
     - php: hhvm
 
@@ -59,9 +51,9 @@ install:
   - composer show --installed
 
 script:
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer test-coverage ; fi
-  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then composer test ; fi
-  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then composer cs ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; fi
+  - if [[ $TEST_COVERAGE != 'true' ]]; then composer test ; fi
+  - if [[ $CHECK_CS == 'true' ]]; then composer cs ; fi
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer upload-coverage ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,69 @@ sudo: false
 
 language: php
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
+
+env:
+  global:
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs --no-scripts"
+
 matrix:
   fast_finish: true
   include:
     - php: 5.5
     - php: 5.6
       env:
-        - EXECUTE_CS_CHECK=true
+        - DEPS=lowest
+    - php: 5.6
+      env:
+        - DEPS=locked
+        - TEST_COVERAGE=true
+    - php: 5.6
+      env:
+        - DEPS=latest
     - php: 7
+      env:
+        - DEPS=lowest
+    - php: 7
+      env:
+        - DEPS=locked
+        - CHECK_CS=true
+    - php: 7
+      env:
+        - DEPS=latest
     - php: hhvm
+      env:
+        - DEPS=lowest
+    - php: hhvm
+      env:
+        - DEPS=locked
+    - php: hhvm
+      env:
+        - DEPS=latest
   allow_failures:
     - php: hhvm
 
 before_install:
-  - composer self-update
+  - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+  - travis_retry composer self-update
 
 install:
-  - travis_retry composer install --no-interaction --ignore-platform-reqs --prefer-source --no-scripts
+  - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
+  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS satooshi/php-coveralls:^1.0 ; fi
+  - travis_retry composer install $COMPOSER_ARGS
+  - composer show --installed
 
 script:
-  - composer test
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer test-coverage ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then composer test ; fi
   - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then composer cs ; fi
+
+after_script:
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer upload-coverage ; fi
 
 notifications:
   email: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Expressive Skeleton and Installer
 
 [![Build Status](https://secure.travis-ci.org/zendframework/zend-expressive-skeleton.svg?branch=master)](https://secure.travis-ci.org/zendframework/zend-expressive-skeleton)
+[![Coverage Status](https://coveralls.io/repos/zendframework/zend-expressive-skeleton/badge.svg?branch=master)](https://coveralls.io/r/zendframework/zend-expressive-skeleton?branch=master)
 
 *Begin developing PSR-7 middleware applications in seconds!*
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Expressive Skeleton and Installer
 
 [![Build Status](https://secure.travis-ci.org/zendframework/zend-expressive-skeleton.svg?branch=master)](https://secure.travis-ci.org/zendframework/zend-expressive-skeleton)
-[![Coverage Status](https://coveralls.io/repos/zendframework/zend-expressive-skeleton/badge.svg?branch=master)](https://coveralls.io/r/zendframework/zend-expressive-skeleton?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/zendframework/zend-expressive-skeleton/badge.svg?branch=master)](https://coveralls.io/github/zendframework/zend-expressive-skeleton?branch=master)
 
 *Begin developing PSR-7 middleware applications in seconds!*
 

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,8 @@
         "cs": "phpcs",
         "cs-fix": "phpcbf",
         "serve": "php -S 0.0.0.0:8080 -t public/ public/index.php",
-        "test": "phpunit"
+        "test": "phpunit",
+        "test-coverage": "phpunit --coverage-clover clover.xml",
+        "upload-coverage": "coveralls -v"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
     </testsuites>
 
     <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+        <whitelist>
             <directory suffix=".php">./src</directory>
             <exclude>./src/ExpressiveInstaller/Resources</exclude>
         </whitelist>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,8 @@
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
     <testsuites>
         <testsuite name="App\\Tests">
             <directory>./test</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,8 @@
 
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
+            <directory suffix=".php">./src</directory>
+            <exclude>./src/ExpressiveInstaller/Resources</exclude>
         </whitelist>
     </filter>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,9 @@
     <filter>
         <whitelist>
             <directory suffix=".php">./src</directory>
-            <exclude>./src/ExpressiveInstaller/Resources</exclude>
+            <exclude>
+                <directory suffix=".php">./src/ExpressiveInstaller/Resources</directory>
+            </exclude>
         </whitelist>
     </filter>
 </phpunit>

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -463,7 +463,7 @@ class OptionalPackages
      *
      * @return bool
      */
-    private static function requestMinimal(IOInterface $io)
+    public static function requestMinimal(IOInterface $io)
     {
         $query = [
             sprintf(

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -178,25 +178,7 @@ class OptionalPackages
 
         // House keeping
         $io->write("<info>Remove installer</info>");
-
-        // Remove test dependencies
-        unset(self::$composerDefinition['autoload-dev']['psr-4']['ExpressiveInstallerTest\\']);
-
-        // Remove installer data
-        unset(self::$composerDefinition['extra']['optional-packages']);
-        if (empty(self::$composerDefinition['extra'])) {
-            unset(self::$composerDefinition['extra']);
-        }
-
-        // Remove installer scripts, only need to do this once
-        unset(self::$composerDefinition['scripts']['pre-update-cmd']);
-        unset(self::$composerDefinition['scripts']['pre-install-cmd']);
-        if (empty(self::$composerDefinition['scripts'])) {
-            unset(self::$composerDefinition['scripts']);
-        }
-
-        // Remove installer script autoloading rules
-        unset(self::$composerDefinition['autoload']['psr-4']['ExpressiveInstaller\\']);
+        self::removeInstallerFromDefinition();
 
         // Update composer definition
         $json->write(self::$composerDefinition);
@@ -223,6 +205,28 @@ class OptionalPackages
             unset(self::$composerDevRequires[$devDependency]);
             unset(self::$composerDefinition['require-dev'][$devDependency]);
         }
+    }
+
+    private static function removeInstallerFromDefinition()
+    {
+        // Remove test dependencies
+        unset(self::$composerDefinition['autoload-dev']['psr-4']['ExpressiveInstallerTest\\']);
+
+        // Remove installer data
+        unset(self::$composerDefinition['extra']['optional-packages']);
+        if (empty(self::$composerDefinition['extra'])) {
+            unset(self::$composerDefinition['extra']);
+        }
+
+        // Remove installer scripts, only need to do this once
+        unset(self::$composerDefinition['scripts']['pre-update-cmd']);
+        unset(self::$composerDefinition['scripts']['pre-install-cmd']);
+        if (empty(self::$composerDefinition['scripts'])) {
+            unset(self::$composerDefinition['scripts']);
+        }
+
+        // Remove installer script autoloading rules
+        unset(self::$composerDefinition['autoload']['psr-4']['ExpressiveInstaller\\']);
     }
 
     /**

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -93,6 +93,8 @@ class OptionalPackages
      * install and update commands on completion.
      *
      * @param Event $event
+     *
+     * @codeCoverageIgnore
      */
     public static function install(Event $event)
     {
@@ -242,6 +244,7 @@ class OptionalPackages
      * @param string      $defaultOption
      *
      * @return bool|int|string
+     * @codeCoverageIgnore
      */
     private static function askQuestion(Composer $composer, IOInterface $io, $question, $defaultOption)
     {
@@ -491,6 +494,8 @@ class OptionalPackages
      *
      * @param IOInterface $io
      * @param string      $projectRoot Project root from which to derive the directory to remove
+     *
+     * @codeCoverageIgnore
      */
     private static function removeDefaultMiddleware(IOInterface $io, $projectRoot)
     {
@@ -509,6 +514,8 @@ class OptionalPackages
      * Recursively remove a directory.
      *
      * @param string $directory
+     *
+     * @codeCoverageIgnore
      */
     private static function recursiveRmdir($directory)
     {
@@ -527,6 +534,8 @@ class OptionalPackages
     /**
      * @param IOInterface $io
      * @param string      $projectRoot
+     *
+     * @codeCoverageIgnore
      */
     private static function clearComposerLockFile($io, $projectRoot)
     {

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -229,6 +229,8 @@ class OptionalPackages
      *
      * @param IOInterface $io
      * @param string      $projectRoot
+     *
+     * @codeCoverageIgnore
      */
     private static function cleanUp(IOInterface $io, $projectRoot)
     {

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -205,8 +205,13 @@ class OptionalPackages
         unset(self::$composerDefinition['autoload']['psr-4']['ExpressiveInstaller\\']);
         unset(self::$composerDefinition['autoload-dev']['psr-4']['ExpressiveInstallerTest\\']);
 
+        // Remove branch-alias
+        unset(self::$composerDefinition['extra']['branch-alias']);
+
         // Remove installer data
         unset(self::$composerDefinition['extra']['optional-packages']);
+
+        // Remove left over
         if (empty(self::$composerDefinition['extra'])) {
             unset(self::$composerDefinition['extra']);
         }

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -211,12 +211,9 @@ class OptionalPackages
             unset(self::$composerDefinition['extra']);
         }
 
-        // Remove installer scripts, only need to do this once
+        // Remove installer scripts
         unset(self::$composerDefinition['scripts']['pre-update-cmd']);
         unset(self::$composerDefinition['scripts']['pre-install-cmd']);
-        if (empty(self::$composerDefinition['scripts'])) {
-            unset(self::$composerDefinition['scripts']);
-        }
     }
 
     /**

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -207,9 +207,13 @@ class OptionalPackages
         }
     }
 
+    /**
+     * Remove the installer from the composer definition
+     */
     private static function removeInstallerFromDefinition()
     {
-        // Remove test dependencies
+        // Remove installer script autoloading rules
+        unset(self::$composerDefinition['autoload']['psr-4']['ExpressiveInstaller\\']);
         unset(self::$composerDefinition['autoload-dev']['psr-4']['ExpressiveInstallerTest\\']);
 
         // Remove installer data
@@ -224,9 +228,6 @@ class OptionalPackages
         if (empty(self::$composerDefinition['scripts'])) {
             unset(self::$composerDefinition['scripts']);
         }
-
-        // Remove installer script autoloading rules
-        unset(self::$composerDefinition['autoload']['psr-4']['ExpressiveInstaller\\']);
     }
 
     /**

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -141,9 +141,6 @@ class OptionalPackages
             // Get answer
             $answer = self::askQuestion($composer, $io, $question, $defaultOption);
 
-            // Save user selected option
-            self::$composerDefinition['extra']['optional-packages'][$questionName] = $answer;
-
             if (is_numeric($answer)) {
                 // Add packages to install
                 if (isset($question['options'][$answer]['packages'])) {
@@ -164,6 +161,9 @@ class OptionalPackages
                     $io->write(sprintf("  <warning>%s</warning>", $question['custom-package-warning']));
                 }
             }
+
+            // Save user selected option
+            self::$composerDefinition['extra']['optional-packages'][$questionName] = $answer;
 
             // Update composer definition
             $json->write(self::$composerDefinition);

--- a/test/ExpressiveInstallerTest/AddPackageTest.php
+++ b/test/ExpressiveInstallerTest/AddPackageTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-skeleton for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-skeleton/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ExpressiveInstallerTest;
+
+use Composer\Package\BasePackage;
+use ExpressiveInstaller\OptionalPackages;
+use Prophecy\Argument;
+
+class AddPackageTest extends InstallerTestCase
+{
+    /**
+     * @dataProvider packageProvider
+     */
+    public function testAddPackage($packageName, $packageVersion, $expectedStability)
+    {
+        // Prepare the installer
+        OptionalPackages::removeDevDependencies();
+
+        $io = $this->prophesize('Composer\IO\IOInterface');
+        $io->write(Argument::containingString('Adding package'))->shouldBeCalled();
+
+        OptionalPackages::addPackage($io->reveal(), $packageName, $packageVersion);
+
+        $this->assertComposerHasPackages(['zendframework/zend-stdlib']);
+        $stabilityFlags = $this->getStabilityFlags();
+
+        // Stability flags are only set for non-stable packages
+        if ($expectedStability) {
+            $this->assertArrayHasKey($packageName, $stabilityFlags);
+            $this->assertEquals($expectedStability, $stabilityFlags[$packageName]);
+        }
+    }
+
+    public function packageProvider()
+    {
+        // $packageName, $packageVersion, $expectedStability
+        return [
+            'dev'    => ['zendframework/zend-stdlib', '1.0.0-dev', BasePackage::STABILITY_DEV],
+            'alpha'  => ['zendframework/zend-stdlib', '1.0.0-alpha2', BasePackage::STABILITY_ALPHA],
+            'beta'   => ['zendframework/zend-stdlib', '1.0.0-beta.3', BasePackage::STABILITY_BETA],
+            'RC'     => ['zendframework/zend-stdlib', '1.0.0-RC4', BasePackage::STABILITY_RC],
+            'stable' => ['zendframework/zend-stdlib', '1.0.0', null],
+        ];
+    }
+}

--- a/test/ExpressiveInstallerTest/ContainersTest.php
+++ b/test/ExpressiveInstallerTest/ContainersTest.php
@@ -13,7 +13,6 @@ use Aura\Di\Container as AuraContainer;
 use ExpressiveInstaller\OptionalPackages;
 use Interop\Container\ContainerInterface;
 use Xtreamwayz\Pimple\Container as PimpleContainer;
-use ReflectionProperty;
 use Zend\Expressive;
 use Zend\ServiceManager\ServiceManager as ZendServiceManagerContainer;
 
@@ -34,19 +33,26 @@ class ContainersTest extends InstallerTestCase
         $expectedResponseStatusCode,
         $expectedContainer
     ) {
-        $r = new ReflectionProperty(OptionalPackages::class, 'config');
-        $r->setAccessible(true);
-        $config = $r->getValue();
+        $io     = $this->prophesize('Composer\IO\IOInterface');
+        $config = $this->getConfig();
 
-        // Install packages
-        $this->installPackage(
-            $config['questions']['container']['options'][$containerOption],
+        // Install container
+        $containerResult = OptionalPackages::processAnswer(
+            $io->reveal(),
+            $config['questions']['container'],
+            $containerOption,
             $copyFilesKey
         );
-        $this->installPackage(
-            $config['questions']['router']['options'][$routerOption],
+        $this->assertTrue($containerResult);
+
+        // Install router
+        $routerResult = OptionalPackages::processAnswer(
+            $io->reveal(),
+            $config['questions']['router'],
+            $routerOption,
             $copyFilesKey
         );
+        $this->assertTrue($routerResult);
 
         // Test container
         $container = $this->getContainer();

--- a/test/ExpressiveInstallerTest/ErrorHandlerTest.php
+++ b/test/ExpressiveInstallerTest/ErrorHandlerTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-skeleton for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-skeleton/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ExpressiveInstallerTest;
+
+use ExpressiveInstaller\OptionalPackages;
+use ReflectionProperty;
+use Zend\Expressive\Container\WhoopsErrorHandlerFactory;
+
+class ErrorHandlerTest extends InstallerTestCase
+{
+    protected $teardownFiles = [
+        '/config/container.php',
+        '/config/autoload/errorhandler.local.php',
+    ];
+
+    public function testErrorHandlerIsNotInstalled()
+    {
+        $r = new ReflectionProperty(OptionalPackages::class, 'config');
+        $r->setAccessible(true);
+        $config = $r->getValue();
+
+        // Install packages
+        $this->installPackage($config['questions']['container']['options'][3], 'minimal-files');
+
+        // Test container
+        $container = $this->getContainer();
+        $this->assertFalse($container->has('Zend\Expressive\FinalHandler'));
+    }
+
+    /**
+     * @dataProvider errorHandlerProvider
+     */
+    public function testErrorHandler(
+        $containerOption,
+        $errorHandlerOption,
+        $copyFilesKey,
+        $expectedErrorHandler
+    ) {
+        $r = new ReflectionProperty(OptionalPackages::class, 'config');
+        $r->setAccessible(true);
+        $config = $r->getValue();
+
+        // Install packages
+        $this->installPackage(
+            $config['questions']['container']['options'][$containerOption],
+            $copyFilesKey
+        );
+        $this->installPackage(
+            $config['questions']['error-handler']['options'][$errorHandlerOption],
+            $copyFilesKey
+        );
+
+        // Test container
+        $container = $this->getContainer();
+        $this->assertTrue($container->has('Zend\Expressive\FinalHandler'));
+
+        $config = $container->get('config');
+        $this->assertEquals(
+            $expectedErrorHandler,
+            $config['dependencies']['factories']['Zend\Expressive\FinalHandler']
+        );
+    }
+
+    public function errorHandlerProvider()
+    {
+        // $containerOption, $errorHandlerOption, $copyFilesKey, $expectedErrorHandler
+        return [
+            'whoops-minimal' => [3, 1, 'minimal-files', WhoopsErrorHandlerFactory::class],
+            'whoops-full'    => [3, 1, 'copy-files', WhoopsErrorHandlerFactory::class],
+        ];
+    }
+}

--- a/test/ExpressiveInstallerTest/ErrorHandlerTest.php
+++ b/test/ExpressiveInstallerTest/ErrorHandlerTest.php
@@ -10,7 +10,6 @@
 namespace ExpressiveInstallerTest;
 
 use ExpressiveInstaller\OptionalPackages;
-use ReflectionProperty;
 use Zend\Expressive\Container\WhoopsErrorHandlerFactory;
 
 class ErrorHandlerTest extends InstallerTestCase
@@ -22,12 +21,17 @@ class ErrorHandlerTest extends InstallerTestCase
 
     public function testErrorHandlerIsNotInstalled()
     {
-        $r = new ReflectionProperty(OptionalPackages::class, 'config');
-        $r->setAccessible(true);
-        $config = $r->getValue();
+        $io     = $this->prophesize('Composer\IO\IOInterface');
+        $config = $this->getConfig();
 
-        // Install packages
-        $this->installPackage($config['questions']['container']['options'][3], 'minimal-files');
+        // Install container
+        $containerResult = OptionalPackages::processAnswer(
+            $io->reveal(),
+            $config['questions']['container'],
+            3,
+            'minimal-files'
+        );
+        $this->assertTrue($containerResult);
 
         // Test container
         $container = $this->getContainer();
@@ -43,19 +47,26 @@ class ErrorHandlerTest extends InstallerTestCase
         $copyFilesKey,
         $expectedErrorHandler
     ) {
-        $r = new ReflectionProperty(OptionalPackages::class, 'config');
-        $r->setAccessible(true);
-        $config = $r->getValue();
+        $io     = $this->prophesize('Composer\IO\IOInterface');
+        $config = $this->getConfig();
 
-        // Install packages
-        $this->installPackage(
-            $config['questions']['container']['options'][$containerOption],
+        // Install container
+        $containerResult = OptionalPackages::processAnswer(
+            $io->reveal(),
+            $config['questions']['container'],
+            $containerOption,
             $copyFilesKey
         );
-        $this->installPackage(
-            $config['questions']['error-handler']['options'][$errorHandlerOption],
+        $this->assertTrue($containerResult);
+
+        // Install error handler
+        $containerResult = OptionalPackages::processAnswer(
+            $io->reveal(),
+            $config['questions']['error-handler'],
+            $errorHandlerOption,
             $copyFilesKey
         );
+        $this->assertTrue($containerResult);
 
         // Test container
         $container = $this->getContainer();

--- a/test/ExpressiveInstallerTest/InstallerTestCase.php
+++ b/test/ExpressiveInstallerTest/InstallerTestCase.php
@@ -30,8 +30,6 @@ class InstallerTestCase extends \PHPUnit_Framework_TestCase
      */
     protected $container;
 
-    protected $response;
-
     protected $teardownFiles = [];
 
     /**
@@ -68,8 +66,6 @@ class InstallerTestCase extends \PHPUnit_Framework_TestCase
 
     protected function setup()
     {
-        $this->response = null;
-
         $this->cleanup();
 
         // Set config

--- a/test/ExpressiveInstallerTest/InstallerTestCase.php
+++ b/test/ExpressiveInstallerTest/InstallerTestCase.php
@@ -121,24 +121,6 @@ class InstallerTestCase extends \PHPUnit_Framework_TestCase
         $this->cleanup();
     }
 
-    protected function installPackage($config, $copyFilesKey)
-    {
-        /* TODO: First we need to set $composerDefinition, $composerRequires, $composerDevRequires and $stabilityFlags;
-        // Add packages to install
-        if (isset($config['packages'])) {
-            foreach ($config['packages'] as $packageName) {
-                OptionalPackages::addPackage($this->io, $packageName, $this->config['packages'][$packageName]);
-            }
-        }*/
-
-        // Copy files
-        if (isset($config[$copyFilesKey])) {
-            foreach ($config[$copyFilesKey] as $source => $target) {
-                OptionalPackages::copyFile($this->io->reveal(), $this->getProjectRoot(), $source, $target);
-            }
-        }
-    }
-
     protected function cleanup()
     {
         foreach ($this->teardownFiles as $file) {

--- a/test/ExpressiveInstallerTest/InstallerTestCase.php
+++ b/test/ExpressiveInstallerTest/InstallerTestCase.php
@@ -37,12 +37,15 @@ class InstallerTestCase extends \PHPUnit_Framework_TestCase
      */
     private $io;
 
-    private $projectRoot;
-
     /**
      * @var ReflectionProperty
      */
     private $refConfig;
+
+    /**
+     * @var ReflectionProperty
+     */
+    private $refProjectRoot;
 
     /**
      * @var ReflectionProperty
@@ -66,8 +69,6 @@ class InstallerTestCase extends \PHPUnit_Framework_TestCase
 
     protected function setup()
     {
-        $this->cleanup();
-
         // Set config
         $this->refConfig = new ReflectionProperty(OptionalPackages::class, 'config');
         $this->refConfig->setAccessible(true);
@@ -104,7 +105,13 @@ class InstallerTestCase extends \PHPUnit_Framework_TestCase
         $this->refStabilityFlags->setAccessible(true);
         $this->refStabilityFlags->setValue($package->getStabilityFlags());
 
-        $this->projectRoot = realpath(dirname($composerFile));
+        // Set project root
+        $this->refProjectRoot = new ReflectionProperty(OptionalPackages::class, 'projectRoot');
+        $this->refProjectRoot->setAccessible(true);
+        $this->refProjectRoot->setValue(realpath(dirname($composerFile)));
+
+        // Cleanup old install files
+        $this->cleanup();
     }
 
     protected function tearDown()
@@ -127,7 +134,7 @@ class InstallerTestCase extends \PHPUnit_Framework_TestCase
         // Copy files
         if (isset($config[$copyFilesKey])) {
             foreach ($config[$copyFilesKey] as $source => $target) {
-                OptionalPackages::copyFile($this->io->reveal(), $this->projectRoot, $source, $target);
+                OptionalPackages::copyFile($this->io->reveal(), $this->getProjectRoot(), $source, $target);
             }
         }
     }
@@ -135,8 +142,8 @@ class InstallerTestCase extends \PHPUnit_Framework_TestCase
     protected function cleanup()
     {
         foreach ($this->teardownFiles as $file) {
-            if (is_file($this->projectRoot . $file)) {
-                unlink($this->projectRoot . $file);
+            if (is_file($this->getProjectRoot() . $file)) {
+                unlink($this->getProjectRoot() . $file);
             }
         }
     }
@@ -168,6 +175,11 @@ class InstallerTestCase extends \PHPUnit_Framework_TestCase
     protected function getConfig()
     {
         return $this->refConfig->getValue();
+    }
+
+    protected function getProjectRoot()
+    {
+        return $this->refProjectRoot->getValue();
     }
 
     protected function getComposerDefinition()

--- a/test/ExpressiveInstallerTest/InstallerTestCase.php
+++ b/test/ExpressiveInstallerTest/InstallerTestCase.php
@@ -190,7 +190,7 @@ class InstallerTestCase extends \PHPUnit_Framework_TestCase
         return $this->refStabilityFlags->getValue();
     }
 
-    protected function composerRequires($package)
+    private function composerHasPackage($package)
     {
         if (array_key_exists($package, $this->getComposerRequires())) {
             return true;
@@ -201,5 +201,48 @@ class InstallerTestCase extends \PHPUnit_Framework_TestCase
         }
 
         return false;
+    }
+
+    private function composerDefinitionHasPackage($package)
+    {
+        $definition = $this->getComposerDefinition();
+
+        if (array_key_exists($package, $definition['require'])) {
+            return true;
+        }
+
+        if (array_key_exists($package, $definition['require-dev'])) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function assertComposerHasPackages(array $packages)
+    {
+        $list = [];
+        foreach ($packages as $package) {
+            if (false === $this->composerHasPackage($package)
+                || false === $this->composerDefinitionHasPackage($package)
+            ) {
+                $list[] = $package;
+            }
+        }
+
+        $this->assertCount(0, $list, sprintf('Several packages were not found "%s"', implode(', ', $list)));
+    }
+
+    public function assertComposerNotHasPackages(array $packages)
+    {
+        $list = [];
+        foreach ($packages as $package) {
+            if (true === $this->composerHasPackage($package)
+                || true === $this->composerDefinitionHasPackage($package)
+            ) {
+                $list[] = $package;
+            }
+        }
+
+        $this->assertCount(0, $list, sprintf('Several packages were found "%s"', implode(', ', $list)));
     }
 }

--- a/test/ExpressiveInstallerTest/ProcessAnswersTest.php
+++ b/test/ExpressiveInstallerTest/ProcessAnswersTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-skeleton for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-skeleton/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ExpressiveInstallerTest;
+
+use ExpressiveInstaller\OptionalPackages;
+use Prophecy\Argument;
+
+class ProcessAnswersTest extends InstallerTestCase
+{
+    protected $teardownFiles = [
+        '/config/container.php',
+    ];
+
+    public function testInvalidAnswer()
+    {
+        $io = $this->prophesize('Composer\IO\IOInterface');
+        $io->write()->shouldNotBeCalled();
+
+        $config       = $this->getConfig();
+        $question     = $config['questions']['container'];
+        $answer       = 'foobar';
+        $copyFilesKey = 'minimal-files';
+        $result       = OptionalPackages::processAnswer($io->reveal(), $question, $answer, $copyFilesKey);
+
+        $this->assertFalse($result);
+        $this->assertFileNotExists($this->getProjectRoot() . '/config/container.php');
+    }
+
+    public function testAnsweredWithN()
+    {
+        $io = $this->prophesize('Composer\IO\IOInterface');
+        $io->write()->shouldNotBeCalled();
+
+        $config       = $this->getConfig();
+        $question     = $config['questions']['container'];
+        $answer       = 'n';
+        $copyFilesKey = 'minimal-files';
+        $result       = OptionalPackages::processAnswer($io->reveal(), $question, $answer, $copyFilesKey);
+
+        $this->assertFalse($result);
+        $this->assertFileNotExists($this->getProjectRoot() . '/config/container.php');
+    }
+
+    public function testAnsweredWithInvalidOption()
+    {
+        $io = $this->prophesize('Composer\IO\IOInterface');
+        $io->write()->shouldNotBeCalled();
+
+        $config       = $this->getConfig();
+        $question     = $config['questions']['container'];
+        $answer       = 10;
+        $copyFilesKey = 'minimal-files';
+        $result       = OptionalPackages::processAnswer($io->reveal(), $question, $answer, $copyFilesKey);
+
+        $this->assertFalse($result);
+        $this->assertFileNotExists($this->getProjectRoot() . '/config/container.php');
+    }
+
+    public function testAnsweredWithValidOption()
+    {
+        // Prepare the installer
+        OptionalPackages::removeDevDependencies();
+
+        $io = $this->prophesize('Composer\IO\IOInterface');
+
+        $io->write(Argument::containingString('Adding package <info>aura/di</info>'))->shouldBeCalled();
+        $io->write(Argument::containingString('Copying <info>/config/container.php</info>'))->shouldBeCalled();
+
+        $config       = $this->getConfig();
+        $question     = $config['questions']['container'];
+        $answer       = 1;
+        $copyFilesKey = 'minimal-files';
+        $result       = OptionalPackages::processAnswer($io->reveal(), $question, $answer, $copyFilesKey);
+
+        $this->assertTrue($result);
+        $this->assertFileExists($this->getProjectRoot() . '/config/container.php');
+        $this->assertComposerHasPackages(['aura/di']);
+    }
+
+    public function testAnsweredWithPackage()
+    {
+        // Prepare the installer
+        OptionalPackages::removeDevDependencies();
+
+        $io = $this->prophesize('Composer\IO\IOInterface');
+
+        $io->write(Argument::containingString('Adding package <info>league/container</info>'))->shouldBeCalled();
+        $io->write(Argument::containingString('<warning>You need to edit public/index.php'))->shouldBeCalled();
+
+        $config       = $this->getConfig();
+        $question     = $config['questions']['container'];
+        $answer       = 'league/container:2.2.0';
+        $copyFilesKey = 'minimal-files';
+        $result       = OptionalPackages::processAnswer($io->reveal(), $question, $answer, $copyFilesKey);
+
+        $this->assertTrue($result);
+        $this->assertFileNotExists($this->getProjectRoot() . '/config/container.php');
+        $this->assertComposerHasPackages(['league/container']);
+    }
+}

--- a/test/ExpressiveInstallerTest/RemoveDevDependenciesTest.php
+++ b/test/ExpressiveInstallerTest/RemoveDevDependenciesTest.php
@@ -14,35 +14,43 @@ use ReflectionMethod;
 
 class RemoveDevDependenciesTest extends InstallerTestCase
 {
-    /**
-     * @dataProvider packageProvider
-     */
-    public function testDevDependenciesRemoval($package)
-    {
-        $this->assertTrue($this->composerRequires($package));
+    private $standardDependencies = [
+        'php',
+        'roave/security-advisories',
+        'zendframework/zend-expressive',
+        'zendframework/zend-expressive-helpers',
+        'zendframework/zend-stdlib',
+        'phpunit/phpunit',
+        'squizlabs/php_codesniffer',
+    ];
 
+    private $devDependencies      = [
+        'aura/di',
+        'composer/composer',
+        'filp/whoops',
+        'xtreamwayz/pimple-container-interop',
+        'zendframework/zend-expressive-aurarouter',
+        'zendframework/zend-expressive-fastroute',
+        'zendframework/zend-expressive-platesrenderer',
+        'zendframework/zend-expressive-twigrenderer',
+        'zendframework/zend-expressive-zendrouter',
+        'zendframework/zend-expressive-zendviewrenderer',
+        'zendframework/zend-servicemanager',
+    ];
+
+    public function testComposerHasAllDependencies()
+    {
+        $this->assertComposerHasPackages($this->standardDependencies);
+        $this->assertComposerHasPackages($this->devDependencies);
+    }
+
+    public function testDevDependenciesAreRemoved()
+    {
         $method = new ReflectionMethod(OptionalPackages::class, 'removeDevDependencies');
         $method->setAccessible(true);
         $method->invoke(OptionalPackages::class);
 
-        $this->assertFalse($this->composerRequires($package));
-    }
-
-    public function packageProvider()
-    {
-        // $package
-        return [
-            'aura-di'                          => ['aura/di'],
-            'composer'                         => ['composer/composer'],
-            'pimple-container-interop'         => ['xtreamwayz/pimple-container-interop'],
-            'whoops'                           => ['filp/whoops'],
-            'zend-expressive-aurarouter'       => ['zendframework/zend-expressive-aurarouter'],
-            'zend-expressive-fastroute'        => ['zendframework/zend-expressive-fastroute'],
-            'zend-expressive-platesrenderer'   => ['zendframework/zend-expressive-platesrenderer'],
-            'zend-expressive-twigrenderer'     => ['zendframework/zend-expressive-twigrenderer'],
-            'zend-expressive-zendrouter'       => ['zendframework/zend-expressive-zendrouter'],
-            'zend-expressive-zendviewrenderer' => ['zendframework/zend-expressive-zendviewrenderer'],
-            'zend-servicemanager'              => ['zendframework/zend-servicemanager'],
-        ];
+        $this->assertComposerHasPackages($this->standardDependencies);
+        $this->assertComposerNotHasPackages($this->devDependencies);
     }
 }

--- a/test/ExpressiveInstallerTest/RemoveDevDependenciesTest.php
+++ b/test/ExpressiveInstallerTest/RemoveDevDependenciesTest.php
@@ -10,7 +10,6 @@
 namespace ExpressiveInstallerTest;
 
 use ExpressiveInstaller\OptionalPackages;
-use ReflectionMethod;
 
 class RemoveDevDependenciesTest extends InstallerTestCase
 {
@@ -46,9 +45,8 @@ class RemoveDevDependenciesTest extends InstallerTestCase
 
     public function testDevDependenciesAreRemoved()
     {
-        $method = new ReflectionMethod(OptionalPackages::class, 'removeDevDependencies');
-        $method->setAccessible(true);
-        $method->invoke(OptionalPackages::class);
+        // Prepare the installer
+        OptionalPackages::removeDevDependencies();
 
         $this->assertComposerHasPackages($this->standardDependencies);
         $this->assertComposerNotHasPackages($this->devDependencies);

--- a/test/ExpressiveInstallerTest/RemoveDevDependenciesTest.php
+++ b/test/ExpressiveInstallerTest/RemoveDevDependenciesTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-skeleton for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-skeleton/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ExpressiveInstallerTest;
+
+use ExpressiveInstaller\OptionalPackages;
+use ReflectionMethod;
+
+class RemoveDevDependenciesTest extends InstallerTestCase
+{
+    /**
+     * @dataProvider packageProvider
+     */
+    public function testDevDependenciesRemoval($package)
+    {
+        $this->assertTrue($this->composerRequires($package));
+
+        $method = new ReflectionMethod(OptionalPackages::class, 'removeDevDependencies');
+        $method->setAccessible(true);
+        $method->invoke(OptionalPackages::class);
+
+        $this->assertFalse($this->composerRequires($package));
+    }
+
+    public function packageProvider()
+    {
+        // $package
+        return [
+            'aura-di'                          => ['aura/di'],
+            'composer'                         => ['composer/composer'],
+            'pimple-container-interop'         => ['xtreamwayz/pimple-container-interop'],
+            'whoops'                           => ['filp/whoops'],
+            'zend-expressive-aurarouter'       => ['zendframework/zend-expressive-aurarouter'],
+            'zend-expressive-fastroute'        => ['zendframework/zend-expressive-fastroute'],
+            'zend-expressive-platesrenderer'   => ['zendframework/zend-expressive-platesrenderer'],
+            'zend-expressive-twigrenderer'     => ['zendframework/zend-expressive-twigrenderer'],
+            'zend-expressive-zendrouter'       => ['zendframework/zend-expressive-zendrouter'],
+            'zend-expressive-zendviewrenderer' => ['zendframework/zend-expressive-zendviewrenderer'],
+            'zend-servicemanager'              => ['zendframework/zend-servicemanager'],
+        ];
+    }
+}

--- a/test/ExpressiveInstallerTest/RemoveInstallerTest.php
+++ b/test/ExpressiveInstallerTest/RemoveInstallerTest.php
@@ -10,7 +10,6 @@
 namespace ExpressiveInstallerTest;
 
 use ExpressiveInstaller\OptionalPackages;
-use ReflectionMethod;
 
 class RemoveInstallerTest extends InstallerTestCase
 {
@@ -27,9 +26,8 @@ class RemoveInstallerTest extends InstallerTestCase
 
     public function testInstallerIsRemoved()
     {
-        $method = new ReflectionMethod(OptionalPackages::class, 'removeInstallerFromDefinition');
-        $method->setAccessible(true);
-        $method->invoke(OptionalPackages::class);
+        // Prepare the installer
+        OptionalPackages::removeInstallerFromDefinition();
 
         $config = $this->getComposerDefinition();
 

--- a/test/ExpressiveInstallerTest/RemoveInstallerTest.php
+++ b/test/ExpressiveInstallerTest/RemoveInstallerTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-skeleton for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-skeleton/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ExpressiveInstallerTest;
+
+use ExpressiveInstaller\OptionalPackages;
+use ReflectionMethod;
+
+class RemoveInstallerTest extends InstallerTestCase
+{
+    public function testComposerHasInstaller()
+    {
+        $config = $this->getComposerDefinition();
+
+        $this->assertTrue(isset($config['autoload']['psr-4']['ExpressiveInstaller\\']));
+        $this->assertTrue(isset($config['autoload-dev']['psr-4']['ExpressiveInstallerTest\\']));
+        $this->assertFalse(isset($config['extra']['optional-packages']));
+        $this->assertTrue(isset($config['scripts']['pre-install-cmd']));
+        $this->assertTrue(isset($config['scripts']['pre-update-cmd']));
+    }
+
+    public function testInstallerIsRemoved()
+    {
+        $method = new ReflectionMethod(OptionalPackages::class, 'removeInstallerFromDefinition');
+        $method->setAccessible(true);
+        $method->invoke(OptionalPackages::class);
+
+        $config = $this->getComposerDefinition();
+
+        $this->assertFalse(isset($config['autoload']['psr-4']['ExpressiveInstaller\\']));
+        $this->assertFalse(isset($config['autoload-dev']['psr-4']['ExpressiveInstallerTest\\']));
+        $this->assertFalse(isset($config['extra']['optional-packages']));
+        $this->assertFalse(isset($config['scripts']['pre-install-cmd']));
+        $this->assertFalse(isset($config['scripts']['pre-update-cmd']));
+    }
+}

--- a/test/ExpressiveInstallerTest/RequestMinimalTest.php
+++ b/test/ExpressiveInstallerTest/RequestMinimalTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive-skeleton for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-skeleton/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ExpressiveInstallerTest;
+
+use ExpressiveInstaller\OptionalPackages;
+use Prophecy\Argument;
+
+class RequestMinimalTest extends InstallerTestCase
+{
+    public function testRequestMinimalInstallIsTrue()
+    {
+        $io = $this->prophesize('Composer\IO\IOInterface');
+        $io->ask(Argument::any(), Argument::any())->willReturn('y');
+
+        $answer = OptionalPackages::requestMinimal($io->reveal());
+        $this->assertTrue($answer);
+    }
+
+    public function testRequestMinimalInstallIsFalse()
+    {
+        $io = $this->prophesize('Composer\IO\IOInterface');
+        $io->ask(Argument::any(), Argument::any())->willReturn('n');
+
+        $answer = OptionalPackages::requestMinimal($io->reveal());
+        $this->assertFalse($answer);
+    }
+}

--- a/test/ExpressiveInstallerTest/RoutersTest.php
+++ b/test/ExpressiveInstallerTest/RoutersTest.php
@@ -12,17 +12,16 @@ namespace ExpressiveInstallerTest;
 use App\Action\HomePageAction;
 use App\Action\PingAction;
 use ExpressiveInstaller\OptionalPackages;
-use ReflectionProperty;
 use Zend\Expressive\Router;
 
 class RoutersTest extends InstallerTestCase
 {
-    protected $teardownFiles = [
+    protected $teardownFiles  = [
         '/config/container.php',
         '/config/autoload/routes.global.php',
     ];
 
-    private $expectedRoutes = [
+    private   $expectedRoutes = [
         [
             'name'            => 'home',
             'path'            => '/',
@@ -48,19 +47,26 @@ class RoutersTest extends InstallerTestCase
         $expectedRoutes,
         $expectedRouter
     ) {
-        $r = new ReflectionProperty(OptionalPackages::class, 'config');
-        $r->setAccessible(true);
-        $config = $r->getValue();
+        $io     = $this->prophesize('Composer\IO\IOInterface');
+        $config = $this->getConfig();
 
-        // Install packages
-        $this->installPackage(
-            $config['questions']['container']['options'][$containerOption],
+        // Install container
+        $containerResult = OptionalPackages::processAnswer(
+            $io->reveal(),
+            $config['questions']['container'],
+            $containerOption,
             $copyFilesKey
         );
-        $this->installPackage(
-            $config['questions']['router']['options'][$routerOption],
+        $this->assertTrue($containerResult);
+
+        // Install router
+        $routerResult = OptionalPackages::processAnswer(
+            $io->reveal(),
+            $config['questions']['router'],
+            $routerOption,
             $copyFilesKey
         );
+        $this->assertTrue($routerResult);
 
         // Test container
         $container = $this->getContainer();

--- a/test/ExpressiveInstallerTest/TemplateRenderersTest.php
+++ b/test/ExpressiveInstallerTest/TemplateRenderersTest.php
@@ -10,7 +10,6 @@
 namespace ExpressiveInstallerTest;
 
 use ExpressiveInstaller\OptionalPackages;
-use ReflectionProperty;
 use Zend\Expressive;
 
 class TemplateRenderersTest extends InstallerTestCase
@@ -40,23 +39,35 @@ class TemplateRenderersTest extends InstallerTestCase
         $expectedResponseStatusCode,
         $expectedTemplateRenderer
     ) {
-        $r = new ReflectionProperty(OptionalPackages::class, 'config');
-        $r->setAccessible(true);
-        $config = $r->getValue();
+        $io     = $this->prophesize('Composer\IO\IOInterface');
+        $config = $this->getConfig();
 
-        // Install packages
-        $this->installPackage(
-            $config['questions']['container']['options'][$containerOption],
+        // Install container
+        $containerResult = OptionalPackages::processAnswer(
+            $io->reveal(),
+            $config['questions']['container'],
+            $containerOption,
             $copyFilesKey
         );
-        $this->installPackage(
-            $config['questions']['router']['options'][$routerOption],
+        $this->assertTrue($containerResult);
+
+        // Install router
+        $routerResult = OptionalPackages::processAnswer(
+            $io->reveal(),
+            $config['questions']['router'],
+            $routerOption,
             $copyFilesKey
         );
-        $this->installPackage(
-            $config['questions']['template-engine']['options'][$templateRendererOption],
+        $this->assertTrue($routerResult);
+
+        // Install template engine
+        $templateEngineResult = OptionalPackages::processAnswer(
+            $io->reveal(),
+            $config['questions']['template-engine'],
+            $templateRendererOption,
             $copyFilesKey
         );
+        $this->assertTrue($templateEngineResult);
 
         // Test container
         $container = $this->getContainer();


### PR DESCRIPTION
This PR is based on #101 

- [x] Parse composer package and populate definitions and requirements
- [x] Add test for cleaning up the de requirements
- [x] Remove installPackage method from the test case and use the function from the installer
- [x] Test 'n' answers
- [x] Test answers with custom packages
- [x] Update travis file
- [x] Drop php 5.5
- [x] Add coveralls support
- [x] Improve coverage 