### PR TITLE
Remove the global config array to ArrayObject conversion

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -30,6 +30,4 @@ if (is_file($cachedConfigFile)) {
     }
 }
 
-// Return an ArrayObject so we can inject the config as a service in Aura.Di
-// and still use array checks like ``is_array``.
-return new ArrayObject($config, ArrayObject::ARRAY_AS_PROPS);
+return $config;

--- a/src/ExpressiveInstaller/Resources/config/container-aura-di.php
+++ b/src/ExpressiveInstaller/Resources/config/container-aura-di.php
@@ -9,8 +9,8 @@ $config = require __DIR__ . '/config.php';
 $builder = new ContainerBuilder();
 $container = $builder->newInstance();
 
-// Inject config
-$container->set('config', $config);
+// Convert config to an object and inject it
+$container->set('config', new ArrayObject($config, ArrayObject::ARRAY_AS_PROPS));
 
 // Inject factories
 foreach ($config['dependencies']['factories'] as $name => $object) {


### PR DESCRIPTION
The config array to object conversion is Aura.Di specific only. Other containers like disco (bitExpert/disco-demos#1) can't handle this. It's better to convert the config array only where needed.

Aura.Di needs this since it's the only way to inject the config into the container as it only accepts objects.

This PR moves the array to object conversion to the Aura.Di specific container.php file.

_NOTE:_ This might be considered a BC break if the config is actually used as an object in 3rd party modules.
