### PR TITLE
Fix composer check script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "pre-install-cmd": "ExpressiveInstaller\\OptionalPackages::install",
         "pre-update-cmd": "ExpressiveInstaller\\OptionalPackages::install",
         "check": [
-            "@cs",
+            "@cs-check",
             "@test"
         ],
         "cs-check": "phpcs",


### PR DESCRIPTION
In commit ea36f0aa27e2e74f0a0a93ede4aff5f692250796 the script was renamed to cs-check for consistency. However the reference in the check script was left untouched.
