### PR TITLE
Update filp/whoops composer version back to ^1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "^2.3",
-        "filp/whoops": "^1.1 || ^2.0",
+        "filp/whoops": "^1.1",
         "composer/composer": "^1.0",
         "zendframework/zend-expressive-aurarouter": "^1.0",
         "zendframework/zend-expressive-fastroute": "^1.0",

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -3,7 +3,7 @@
 return [
     'packages' => [
         'aura/di'                                        => '^3.0',
-        'filp/whoops'                                    => '^1.1 || ^2.0',
+        'filp/whoops'                                    => '^1.1',
         'xtreamwayz/pimple-container-interop'            => '^1.0',
         'zendframework/zend-expressive-aurarouter'       => '^1.0',
         'zendframework/zend-expressive-fastroute'        => '^1.0',


### PR DESCRIPTION
Hello there - long-time Zend user, first time contributor.

The current composer version assignment for Whoops ('filp/whoops') is "^1.1 || ^2.0".

The issue here is that the following Whoops repo commit https://github.com/filp/whoops/commit/26f3dba7b5596403611f7a792dd54213bccd7968#diff-55a3eb0d95a814f13e292b82d6177eb7 (since 2.0.0-alpha1 tag) removed the \Whoops\Handler\JsonResponseHandler::onlyForAjaxRequests method from the codebase.

Consequently, when attempting to use the Zend\Expressive\Container\WhoopsFactory (to use JsonResponseHandler configuration for example):
```
    'dependencies' => [
        'invokables' => [
            'Zend\Expressive\WhoopsPageHandler' => Whoops\Handler\PrettyPageHandler::class,
        ],
        'factories' => [
            'Zend\Expressive\Whoops' => Zend\Expressive\Container\WhoopsFactory::class,
            'Zend\Expressive\FinalHandler' => Zend\Expressive\Container\WhoopsErrorHandlerFactory::class,
        ],
    ],
```

We get a fatal error since the 'onlyForAjaxRequests' method no longer exists and the WhoopsFactory uses it as part of its configuration:
```
if (isset($config['json_exceptions']['ajax_only'])) {
  $handler->onlyForAjaxRequests(true);
}
```

This PR proposes to resolve the issue by reverting the 'filp/whoops' version to just "^1.1", which is the consistent with the Zend Expressive repo.

Note: I also noticed that the installer creates the ['whoops']['json_exceptions'] configuration setting by default, but in fact it is only leveraged by the WhoopsFactory which is not part of default configuration. Should this somehow be noted to prevent confusion?