### PR TITLE
Add support for the standalone Twig_Environment

### DIFF
--- a/src/ExpressiveInstaller/Resources/config/templates-twig.php
+++ b/src/ExpressiveInstaller/Resources/config/templates-twig.php
@@ -6,6 +6,9 @@ return [
             'Zend\Expressive\FinalHandler' =>
                 Zend\Expressive\Container\TemplatedErrorHandlerFactory::class,
 
+            Twig_Environment::class =>
+                Zend\Expressive\Twig\TwigEnvironmentFactory::class,
+
             Zend\Expressive\Template\TemplateRendererInterface::class =>
                 Zend\Expressive\Twig\TwigRendererFactory::class,
         ],


### PR DESCRIPTION
This requires a zend-expressive-twigrenderer version with zendframework/zend-expressive-twigrenderer#15 merged. Without that PR this doesn't do much and doesn't break anything.