### PR TITLE
Do not suffix document root with '/'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
-        "serve": "php -S 0.0.0.0:8080 -t public/ public/index.php",
+        "serve": "php -S 0.0.0.0:8080 -t public public/index.php",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "upload-coverage": "coveralls -v"


### PR DESCRIPTION
Document root path with '/' in the end of document root seems not to work on Windows (while works on Ubuntu). Removing it works on both (Windows & Ubuntu).

fixes #103