### PR TITLE
Register the new TwigEnvironment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,6 @@ notifications:
 
 matrix:
   include:
-    - php: 5.5
-      env:
-        - DEPS=lowest
-    - php: 5.5
-      env:
-        - DEPS=latest
     - php: 5.6
       env:
         - DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     },
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "roave/security-advisories": "dev-master",
         "zendframework/zend-expressive": "^1.0",
         "zendframework/zend-expressive-helpers": "^2.0",

--- a/src/ExpressiveInstaller/Resources/config/templates-twig.php
+++ b/src/ExpressiveInstaller/Resources/config/templates-twig.php
@@ -8,6 +8,8 @@ return [
 
             Zend\Expressive\Template\TemplateRendererInterface::class =>
                 Zend\Expressive\Twig\TwigRendererFactory::class,
+
+            Twig_Environment::class => Zend\Expressive\Twig\TwigEnvironmentFactory::class,
         ],
     ],
 


### PR DESCRIPTION
Register the new TwigEnvironmentFactory which was introduced with zendframework/zend-expressive-twigrenderer#15 in version 1.2.0.

This is a hotfix for #126. It's already included in the develop branch.