### PR TITLE
Prevent global variables references

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -10,15 +10,20 @@ if (php_sapi_name() === 'cli-server'
 chdir(dirname(__DIR__));
 require 'vendor/autoload.php';
 
-/** @var \Interop\Container\ContainerInterface $container */
-$container = require 'config/container.php';
+/**
+ * Self-called anonymous function that creates its own scope and keep the global namespace clean.
+ */
+call_user_func(function () {
+    /** @var \Interop\Container\ContainerInterface $container */
+    $container = require 'config/container.php';
 
-/** @var \Zend\Expressive\Application $app */
-$app = $container->get(\Zend\Expressive\Application::class);
+    /** @var \Zend\Expressive\Application $app */
+    $app = $container->get(\Zend\Expressive\Application::class);
 
-// Import programmatic/declarative middleware pipeline and routing
-// configuration statements
-require 'config/pipeline.php';
-require 'config/routes.php';
+    // Import programmatic/declarative middleware pipeline and routing
+    // configuration statements
+    require 'config/pipeline.php';
+    require 'config/routes.php';
 
-$app->run();
+    $app->run();
+});


### PR DESCRIPTION
The skeleton actually requires files through its index file:
- config/config.php
- config/container.php (dynamically created)

Those files expose few variables ($container, $cachedConfigFile, $config, ...etc), which remains accessible within the app, thought the `global` keyword.

This PR close the access of those global variables in expressive by running inclusions within an anonymous scope in the `public/index.php`, and discourage forever usage of the `global` keyword.