### PR TITLE
Write whoops configuration to development.local.php.dist

### DIFF
--- a/config/autoload/development.local.php.dist
+++ b/config/autoload/development.local.php.dist
@@ -10,7 +10,5 @@
  * `composer development-enable`.
  */
 
-use Zend\ConfigAggregator\ConfigAggregator;
-
 return [
 ];

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -452,8 +452,9 @@ class OptionalPackages
 
             // Copy files
             if (isset($question['options'][$answer][$this->installType])) {
+                $force = ! empty($question['force']);
                 foreach ($question['options'][$answer][$this->installType] as $resource => $target) {
-                    $this->copyResource($resource, $target);
+                    $this->copyResource($resource, $target, $force);
                 }
             }
 

--- a/src/ExpressiveInstaller/Resources/config/error-handler-whoops.php
+++ b/src/ExpressiveInstaller/Resources/config/error-handler-whoops.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Development-only configuration.
+ *
+ * Put settings you want enabled when under development mode in this file, and
+ * check it into your repository.
+ *
+ * Developers on your team will then automatically enable them by calling on
+ * `composer development-enable`.
+ */
+
 use Zend\Expressive\Container;
 use Zend\Expressive\Middleware\ErrorResponseGenerator;
 

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -241,6 +241,7 @@ return [
             'default'        => 1,
             'required'       => false,
             'custom-package' => true,
+            'force'          => true,
             'options'        => [
                 1 => [
                     'name'     => 'Whoops',
@@ -248,13 +249,13 @@ return [
                         'filp/whoops',
                     ],
                     'flat' => [
-                        'Resources/config/error-handler-whoops.php' => 'config/autoload/errorhandler.local.php',
+                        'Resources/config/error-handler-whoops.php' => 'config/autoload/development.local.php.dist',
                     ],
                     'modular' => [
-                        'Resources/config/error-handler-whoops.php' => 'config/autoload/errorhandler.local.php',
+                        'Resources/config/error-handler-whoops.php' => 'config/autoload/development.local.php.dist',
                     ],
                     'minimal' => [
-                        'Resources/config/error-handler-whoops.php' => 'config/autoload/errorhandler.local.php',
+                        'Resources/config/error-handler-whoops.php' => 'config/autoload/development.local.php.dist',
                     ],
                 ],
             ],

--- a/test/ExpressiveInstallerTest/ErrorHandlerTest.php
+++ b/test/ExpressiveInstallerTest/ErrorHandlerTest.php
@@ -50,6 +50,9 @@ class ErrorHandlerTest extends OptionalPackagesTestCase
         );
         $this->assertTrue($containerResult);
 
+        // Enable development mode
+        $this->enableDevelopmentMode();
+
         // Test container
         $container = $this->getContainer();
         $this->assertTrue($container->has(ErrorResponseGenerator::class));
@@ -84,6 +87,9 @@ class ErrorHandlerTest extends OptionalPackagesTestCase
             $errorHandlerOption
         );
         $this->assertTrue($containerResult);
+
+        // Enable development mode
+        $this->enableDevelopmentMode();
 
         // Test container
         $container = $this->getContainer();

--- a/test/ExpressiveInstallerTest/ProjectSandboxTrait.php
+++ b/test/ExpressiveInstallerTest/ProjectSandboxTrait.php
@@ -12,6 +12,7 @@ use App\Action\PingAction;
 use DirectoryIterator;
 use ExpressiveInstaller\OptionalPackages;
 use Interop\Container\ContainerInterface;
+use PHPUnit\Framework\Assert;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Expressive\Application;
@@ -89,6 +90,33 @@ trait ProjectSandboxTrait
                 $this->setUpAlternateAutoloader('/src/App/src/', true);
                 break;
         }
+    }
+
+    /**
+     * Enable development-mode configuration within the sandbox.
+     */
+    protected function enableDevelopmentMode()
+    {
+        $target = sprintf(
+            '%s%sconfig%sdevelopment.config.php',
+            $this->projectRoot,
+            DIRECTORY_SEPARATOR,
+            DIRECTORY_SEPARATOR
+        );
+        copy($target . '.dist', $target);
+
+        Assert::assertFileExists($target);
+
+        $target = sprintf(
+            '%s%sconfig%sautoload%sdevelopment.local.php',
+            $this->projectRoot,
+            DIRECTORY_SEPARATOR,
+            DIRECTORY_SEPARATOR,
+            DIRECTORY_SEPARATOR
+        );
+        copy($target . '.dist', $target);
+
+        Assert::assertFileExists($target);
     }
 
     /**


### PR DESCRIPTION
It makes most sense to put the Whoops configuration in development mode; this patch accomplishes that.

Additionally, it updates the `config/autoload/development.local.php.dist` file to remove the import statement on the `ConfigAggregator`, as it was unnecessary.