### PR TITLE
Added zend-expressive-tooling to dev requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "zendframework/zend-expressive-helpers": "^3.0.1",
         "zendframework/zend-stdlib": "^3.1",
         "zendframework/zend-config-aggregator": "^0.2.0",
-        "zendframework/zend-component-installer": "~1.0 || ^0.6.0"
+        "zendframework/zend-component-installer": "~1.0 || ^0.7.0"
     },
     "require-dev": {
         "aura/di": "^3.2",

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -324,7 +324,11 @@ class OptionalPackages
                 ));
         }
 
-        foreach ($this->config['application'][$this->installType] as $resource => $target) {
+        foreach ($this->config['application'][$this->installType]['packages'] as $package => $constraint) {
+            $this->addPackage($package, $constraint);
+        }
+
+        foreach ($this->config['application'][$this->installType]['resources'] as $resource => $target) {
             $this->copyResource($resource, $target);
         }
     }

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -16,14 +16,23 @@ return [
 
     'require-dev' => [
         'filp/whoops',
+        'zendframework/zend-expressive-tooling',
     ],
 
     'application' => [
         'flat' => [
-            'Resources/src/ConfigProvider.flat.php' => 'src/App/ConfigProvider.php',
+            'packages' => [],
+            'resources' => [
+                'Resources/src/ConfigProvider.flat.php' => 'src/App/ConfigProvider.php',
+            ],
         ],
         'modular' => [
-            'Resources/src/ConfigProvider.modular.php' => 'src/App/src/ConfigProvider.php',
+            'packages' => [
+                'zendframework/zend-expressive-tooling' => '^0.3.1',
+            ],
+            'resources' => [
+                'Resources/src/ConfigProvider.modular.php' => 'src/App/src/ConfigProvider.php',
+            ],
         ],
     ],
 

--- a/test/ExpressiveInstallerTest/SetupDefaultAppTest.php
+++ b/test/ExpressiveInstallerTest/SetupDefaultAppTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-skeleton for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-skeleton/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ExpressiveInstallerTest;
+
+use ExpressiveInstaller\OptionalPackages;
+
+class SetupDefaultAppTest extends OptionalPackagesTestCase
+{
+    use ProjectSandboxTrait;
+
+    /**
+     * @var OptionalPackages
+     */
+    private $installer;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->projectRoot = $this->copyProjectFilesToTempFilesystem();
+        $this->installer   = $this->createOptionalPackages($this->projectRoot);
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        chdir($this->packageRoot);
+        $this->recursiveDelete($this->projectRoot);
+        $this->tearDownAlternateAutoloader();
+    }
+
+    public function testModularInstallationAddsToolingSupportAsDevRequirement()
+    {
+        $this->prepareSandboxForInstallType(OptionalPackages::INSTALL_MODULAR, $this->installer);
+        $this->assertPackage(
+            'zendframework/zend-expressive-tooling',
+            $this->installer,
+            'zend-expressive-tooling package was not injected into composer.json'
+        );
+    }
+
+    public function testFlatInstallationDoesNotAddToolingSupport()
+    {
+        $this->prepareSandboxForInstallType(OptionalPackages::INSTALL_FLAT, $this->installer);
+        $this->assertNotPackage(
+            'zendframework/zend-expressive-tooling',
+            $this->installer,
+            'zend-expressive-tooling package WAS injected into composer.json, but should not have been'
+        );
+    }
+}


### PR DESCRIPTION
This patch updates the installer to also add the zend-expressive-tooling package *if* a modular application layout is selected initially.

Required upping the minimum requirement for zend-component-installer to `^0.7`, as the latest version of zend-expressive-tooling depends on that version or higher..

Fixes #134