### PR TITLE
Update to zend-expressive-helpers 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,10 @@ before_install:
   - travis_retry composer self-update
 
 install:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - travis_retry composer install $COMPOSER_ARGS
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - composer show
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be documented in this file, in reverse 
   string instead of using `::class` notation. Using a string name makes it clear
   the service is not a concrete class or interface name.
 
+- [#143](https://github.com/organization/project/pull/143) updates dependencies
+  to pick up the Expressive 2.0.2 release, zend-expressive-helpers 4.0 release,
+  and renderer releases related to the helpers 4.0 release.
+
 ### Deprecated
 
 - Nothing.

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "roave/security-advisories": "dev-master",
         "zendframework/zend-component-installer": "^1.0 || ^0.7.0",
         "zendframework/zend-config-aggregator": "^0.2.0",
-        "zendframework/zend-expressive": "^2.0",
-        "zendframework/zend-expressive-helpers": "^3.0.1",
+        "zendframework/zend-expressive": "^2.0.2",
+        "zendframework/zend-expressive-helpers": "^4.0",
         "zendframework/zend-stdlib": "^3.1"
     },
     "require-dev": {
@@ -33,10 +33,10 @@
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-expressive-aurarouter": "^2.0",
         "zendframework/zend-expressive-fastroute": "^2.0",
-        "zendframework/zend-expressive-platesrenderer": "^1.2.1",
-        "zendframework/zend-expressive-twigrenderer": "^1.3",
+        "zendframework/zend-expressive-platesrenderer": "^1.3",
+        "zendframework/zend-expressive-twigrenderer": "^1.4",
         "zendframework/zend-expressive-zendrouter": "^2.0.1",
-        "zendframework/zend-expressive-zendviewrenderer": "^1.3",
+        "zendframework/zend-expressive-zendviewrenderer": "^1.4",
         "zendframework/zend-servicemanager": "^3.3",
         "zfcampus/zf-development-mode": "^3.1"
     },

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -7,10 +7,10 @@ return [
         'xtreamwayz/pimple-container-interop'            => '^1.0',
         'zendframework/zend-expressive-aurarouter'       => '^2.0',
         'zendframework/zend-expressive-fastroute'        => '^2.0',
-        'zendframework/zend-expressive-platesrenderer'   => '^1.2.1',
-        'zendframework/zend-expressive-twigrenderer'     => '^1.3',
+        'zendframework/zend-expressive-platesrenderer'   => '^1.3',
+        'zendframework/zend-expressive-twigrenderer'     => '^1.4',
         'zendframework/zend-expressive-zendrouter'       => '^2.0.1',
-        'zendframework/zend-expressive-zendviewrenderer' => '^1.3',
+        'zendframework/zend-expressive-zendviewrenderer' => '^1.4',
         'zendframework/zend-servicemanager'              => '^3.3',
     ],
 
@@ -28,7 +28,7 @@ return [
         ],
         'modular' => [
             'packages' => [
-                'zendframework/zend-expressive-tooling' => '^0.3.1',
+                'zendframework/zend-expressive-tooling' => '^0.3.2',
             ],
             'resources' => [
                 'Resources/src/ConfigProvider.modular.php' => 'src/App/src/ConfigProvider.php',


### PR DESCRIPTION
zend-expressive-helpers 4.0 updates to PSR-11 and PSR-15 interfaces, and, as such, is backwards incompatible with previous releases for purposes of extension. For purposes of consumption, which is what the skeleton does, it is fully backwards compatible.

Due to the BC breaks, new minor releases of each renderer were made that add support for the helpers 4.0 series.

As such, this patch updates to use zend-expressive-helpers 4.0, and to install the renderer versions compatible with that release.

Additionally

- it updates the zend-expressive-tooling minimum supported version to pick up the latest bugfixes.
- it updates the zend-expressive minimum supported version to pick up the latest bugfixes.