### PR TITLE
Remove deprecated config entry

### DIFF
--- a/config/autoload/zend-expressive.global.php
+++ b/config/autoload/zend-expressive.global.php
@@ -13,9 +13,6 @@ return [
     'debug' => false,
 
     'zend-expressive' => [
-        // Enable exception-based error handling via standard middleware.
-        'raise_throwables' => true,
-
         // Enable programmatic pipeline: Any `middleware_pipeline` or `routes`
         // configuration will be ignored when creating the `Application` instance.
         'programmatic_pipeline' => true,


### PR DESCRIPTION
removes `raise_throwables` key from default config.