### PR TITLE
Moved bin scripts to apps bin folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "homepage": "https://github.com/zendframework/zend-expressive-skeleton",
     "license": "BSD-3-Clause",
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "bin-dir": "bin"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
I thought it was more convenient to call bin scripts from your application as:

`php bin/zf-development-mode enable` or `php bin/expressive-module create User`

vs

`php vendor/bin/expressive-module create User`

Simple change, doesn't break anything.