### PR TITLE
Updated to stable dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "roave/security-advisories": "dev-master",
-        "zendframework/zend-component-installer": "^1.0 || ^0.7.1",
-        "zendframework/zend-config-aggregator": "^0.2.0",
+        "zendframework/zend-component-installer": "^1.0",
+        "zendframework/zend-config-aggregator": "^1.0",
         "zendframework/zend-expressive": "^2.0.2",
         "zendframework/zend-expressive-helpers": "^4.0",
         "zendframework/zend-stdlib": "^3.1"


### PR DESCRIPTION
The following now have stable 1.0 versions:

- zend-config-aggregator
- zend-component-installer

Further, the APIs of each are exactly the same as the last stable 0.X releases, meaning they are 100% compatible.