### PR TITLE
Add option to use Auryn as a container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#161](https://github.com/zendframework/zend-expressive-skeleton/pull/161)
+  adds support for Auryn to be used as a container via a wrapper.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "composer/composer": "^1.3.2",
         "filp/whoops": "^2.1.7",
         "mikey179/vfsstream": "^1.6.4",
+        "northwoods/container": "^1.2",
         "phpunit/phpunit": "^6.0.8 || ^5.7.15",
         "squizlabs/php_codesniffer": "^2.8.1",
         "xtreamwayz/pimple-container-interop": "^1.0",

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -105,6 +105,7 @@ class OptionalPackages
         'composer/composer',
         'filp/whoops',
         'mikey179/vfsstream',
+        'northwoods/container',
         'xtreamwayz/pimple-container-interop',
         'zendframework/zend-coding-standard',
         'zendframework/zend-expressive-aurarouter',

--- a/src/ExpressiveInstaller/Resources/config/container-auryn.php
+++ b/src/ExpressiveInstaller/Resources/config/container-auryn.php
@@ -1,0 +1,24 @@
+<?php
+
+use Northwoods\Container\InjectorBuilder;
+use Northwoods\Container\Config;
+use Psr\Container\ContainerInterface;
+
+// Load configuration
+$config = require __DIR__ . '/config.php';
+
+$builder = new InjectorBuilder([
+    new Config\ContainerConfig(),
+    new Config\ServiceConfig(isset($config['dependencies']) ? $config['dependencies'] : []),
+]);
+
+/** @var \Auryn\Injector */
+$injector = $builder->build();
+
+$injector->share('config')->delegate('config', function () use ($config) {
+    // Auryn requires that all injections resolve to an object.
+    // Wrap the config array with an ArrayObject to appease the gods.
+    return new ArrayObject($config);
+});
+
+return $injector->make(ContainerInterface::class);

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -4,6 +4,7 @@ return [
     'packages' => [
         'aura/di'                                        => '^3.2',
         'filp/whoops'                                    => '^2.1.7',
+        'northwoods/container'                           => '^1.2',
         'xtreamwayz/pimple-container-interop'            => '^1.0',
         'zendframework/zend-expressive-aurarouter'       => '^2.0',
         'zendframework/zend-expressive-fastroute'        => '^2.0',
@@ -95,6 +96,21 @@ return [
                     ],
                     'minimal' => [
                         'Resources/config/container-zend-servicemanager.php' => 'config/container.php',
+                    ],
+                ],
+                4 => [
+                    'name'     => 'Auryn',
+                    'packages' => [
+                        'northwoods/container',
+                    ],
+                    'flat' => [
+                        'Resources/config/container-auryn.php' => 'config/container.php',
+                    ],
+                    'modular' => [
+                        'Resources/config/container-auryn.php' => 'config/container.php',
+                    ],
+                    'minimal' => [
+                        'Resources/config/container-auryn.php' => 'config/container.php',
                     ],
                 ],
             ],

--- a/test/ExpressiveInstallerTest/ContainersTest.php
+++ b/test/ExpressiveInstallerTest/ContainersTest.php
@@ -9,6 +9,7 @@ namespace ExpressiveInstallerTest;
 
 use Aura\Di\Container as AuraContainer;
 use ExpressiveInstaller\OptionalPackages;
+use Northwoods\Container\InjectorContainer as AurynContainer;
 use Psr\Container\ContainerInterface;
 use Xtreamwayz\Pimple\Container as PimpleContainer;
 use Zend\Expressive;
@@ -104,6 +105,9 @@ class ContainersTest extends OptionalPackagesTestCase
             'zend-sm-minimal' => [OptionalPackages::INSTALL_MINIMAL, 3, 2, 'minimal-files', 404, ZendServiceManagerContainer::class],
             'zend-sm-flat'    => [OptionalPackages::INSTALL_FLAT,    3, 2, 'copy-files', 200, ZendServiceManagerContainer::class],
             'zend-sm-modular' => [OptionalPackages::INSTALL_MODULAR, 3, 2, 'copy-files', 200, ZendServiceManagerContainer::class],
+            'auryn-minimal'   => [OptionalPackages::INSTALL_MINIMAL, 4, 2, 'minimal-files', 404, AurynContainer::class],
+            'auryn-flat'      => [OptionalPackages::INSTALL_FLAT,    4, 2, 'copy-files', 200, AurynContainer::class],
+            'auryn-modular'   => [OptionalPackages::INSTALL_MODULAR, 4, 2, 'copy-files', 200, AurynContainer::class],
         ];
         // @codingStandardsIgnoreEnd
     }


### PR DESCRIPTION
Auryn provides a powerful reflection-based injector. Although Auryn
itself does not implement PSR-11 a wrapper does exist for it.

Depends on changes from #160.