### PR TITLE
Hotfix aura delegator factory

### DIFF
--- a/src/ExpressiveInstaller/Resources/src/ExpressiveAuraConfig.php
+++ b/src/ExpressiveInstaller/Resources/src/ExpressiveAuraConfig.php
@@ -133,6 +133,7 @@ class ExpressiveAuraConfig implements ContainerConfigInterface
                 // Marshal from factory
                 $serviceFactory = $dependencies['factories'][$service];
                 $factory = function () use ($service, $serviceFactory, $container) {
+                    $serviceFactory = !is_object($serviceFactory) ? new $serviceFactory : $serviceFactory;
                     return $serviceFactory($container, $service);
                 };
                 unset($dependencies['factories'][$service]);

--- a/src/ExpressiveInstaller/Resources/src/ExpressiveAuraConfig.php
+++ b/src/ExpressiveInstaller/Resources/src/ExpressiveAuraConfig.php
@@ -154,7 +154,9 @@ class ExpressiveAuraConfig implements ContainerConfigInterface
             $delegatorFactory = new ExpressiveAuraDelegatorFactory($delegatorNames, $factory);
             $container->set(
                 $service,
-                $container->lazyGetCall($delegatorFactory, 'build', $container, $service)
+                $container->lazy(function () use ($delegatorFactory, $container, $service) {
+                    return $delegatorFactory->build($container, $service);
+                })
             );
         }
 


### PR DESCRIPTION
`$delegatorFactory = new ExpressiveAuraDelegatorFactory($delegatorNames, $factory);`
This is an object and can't be used in lazyGetCall method, because Aura.DI is waiting for string (class name) in it's getter, so lazy method with closure inside fix it.

Also if callback object has it's own factory need to initialize it first