### PR TITLE
Explicitly require http-middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,11 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
+        "http-interop/http-middleware": "^0.4.1",
         "roave/security-advisories": "dev-master",
         "zendframework/zend-component-installer": "^1.0",
         "zendframework/zend-config-aggregator": "^1.0",
-        "zendframework/zend-expressive": "^2.0.2",
+        "zendframework/zend-expressive": "^2.0.5",
         "zendframework/zend-expressive-helpers": "^4.0",
         "zendframework/zend-stdlib": "^3.1"
     },


### PR DESCRIPTION
This should prevent issues with installation due to the webimpress/http-middleware-compatibility plugin.

Prior to this change, after the plugin triggered, an exception would occur in the installer.