### PR TITLE
Fix composer serve command on WSL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "clear-config-cache": "php bin/clear-config-cache.php",
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
-        "serve": "php -S 0.0.0.0:8080 -t public public/index.php",
+        "serve": "php -S 0.0.0.0:8080 -t public index.php",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "upload-coverage": "coveralls -v"


### PR DESCRIPTION
Using `composer serve` on WSL adds an extra `public` path so it can't find the `index.php` file. As the root path is already set, it's not needed in front of the index file.