### PR TITLE
Fixes syntax of `composer serve` script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,7 @@
         "clear-config-cache": "php bin/clear-config-cache.php",
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
-        "serve": "php -S 0.0.0.0:8080 -t public index.php",
+        "serve": "php -S 0.0.0.0:8080 -t public/ public/index.php",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "upload-coverage": "coveralls -v"


### PR DESCRIPTION
For some reason, the script was "updated" for the release-3.0.0 branch to `php -S 0.0.0.0:8080 -t public index.php`, which will not work (`index.php` is in the `public/` subdirectory, not the root directory).

Updates to make it work properly.