### PR TITLE
Adds zend-expressive-tooling as a development requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "zendframework/zend-expressive-aurarouter": "^3.0.0alpha2",
         "zendframework/zend-expressive-fastroute": "^3.0.0alpha1",
         "zendframework/zend-expressive-platesrenderer": "^2.0.0alpha1",
+        "zendframework/zend-expressive-tooling": "^1.0.0alpha2",
         "zendframework/zend-expressive-twigrenderer": "^2.0.0alpha1",
         "zendframework/zend-expressive-zendrouter": "^3.0.0alpha2",
         "zendframework/zend-expressive-zendviewrenderer": "^2.0.0alpha2",
@@ -81,6 +82,7 @@
         "development-disable": "zf-development-mode disable",
         "development-enable": "zf-development-mode enable",
         "development-status": "zf-development-mode status",
+        "expressive": "expressive --ansi",
         "check": [
             "@cs-check",
             "@test"

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -20,7 +20,6 @@ return [
 
     'require-dev' => [
         'filp/whoops',
-        'zendframework/zend-expressive-tooling',
     ],
 
     'application' => [
@@ -32,7 +31,6 @@ return [
         ],
         'modular' => [
             'packages' => [
-                'zendframework/zend-expressive-tooling' => '^1.0.0alpha1 || ^1.0',
             ],
             'resources' => [
                 'Resources/src/ConfigProvider.modular.php' => 'src/App/src/ConfigProvider.php',

--- a/test/ExpressiveInstallerTest/SetupDefaultAppTest.php
+++ b/test/ExpressiveInstallerTest/SetupDefaultAppTest.php
@@ -44,14 +44,4 @@ class SetupDefaultAppTest extends OptionalPackagesTestCase
             'zend-expressive-tooling package was not injected into composer.json'
         );
     }
-
-    public function testFlatInstallationDoesNotAddToolingSupport()
-    {
-        $this->prepareSandboxForInstallType(OptionalPackages::INSTALL_FLAT, $this->installer);
-        $this->assertNotPackage(
-            'zendframework/zend-expressive-tooling',
-            $this->installer,
-            'zend-expressive-tooling package WAS injected into composer.json, but should not have been'
-        );
-    }
 }


### PR DESCRIPTION
This adds zend-expressive-tooling as a development requirement, and adds the composer script "expressive", resolving to `vendor/bin/expressive --ansi`.

Considering that the tooling provides support for creating middleware and modules, and will add more features in the future, this is a reasonably expected package to have available in the skeleton.