### PR TITLE
Have pipeline and route files return closures

### DIFF
--- a/config/pipeline.php
+++ b/config/pipeline.php
@@ -2,60 +2,62 @@
 
 declare(strict_types=1);
 
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Application;
 use Zend\Expressive\Helper\ServerUrlMiddleware;
 use Zend\Expressive\Helper\UrlHelperMiddleware;
+use Zend\Expressive\MiddlewareFactory;
+use Zend\Expressive\Middleware\DispatchMiddleware;
 use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Middleware\NotFoundMiddleware;
-use Zend\Expressive\Router\DispatchMiddleware;
-use Zend\Expressive\Router\PathBasedRoutingMiddleware;
+use Zend\Expressive\Middleware\RouteMiddleware;
 use Zend\Stratigility\Middleware\ErrorHandler;
 
 /**
  * Setup middleware pipeline:
  */
+return function (Application $app, MiddlewareFactory $factory, ContainerInterface $container) : void {
+    // The error handler should be the first (most outer) middleware to catch
+    // all Exceptions.
+    $app->pipe(ErrorHandler::class);
+    $app->pipe(ServerUrlMiddleware::class);
 
-/** @var \Zend\Expressive\Application $app */
+    // Pipe more middleware here that you want to execute on every request:
+    // - bootstrapping
+    // - pre-conditions
+    // - modifications to outgoing responses
+    //
+    // Piped Middleware may be either callables or service names. Middleware may
+    // also be passed as an array; each item in the array must resolve to
+    // middleware eventually (i.e., callable or service name).
+    //
+    // Middleware can be attached to specific paths, allowing you to mix and match
+    // applications under a common domain.  The handlers in each middleware
+    // attached this way will see a URI with the MATCHED PATH SEGMENT REMOVED!!!
+    //
+    // - $app->pipe('/api', $apiMiddleware);
+    // - $app->pipe('/docs', $apiDocMiddleware);
+    // - $app->pipe('/files', $filesMiddleware);
 
-// The error handler should be the first (most outer) middleware to catch
-// all Exceptions.
-$app->pipe(ErrorHandler::class);
-$app->pipe(ServerUrlMiddleware::class);
+    // Register the routing middleware in the middleware pipeline
+    $app->pipe(RouteMiddleware::class);
+    $app->pipe(ImplicitHeadMiddleware::class);
+    $app->pipe(ImplicitOptionsMiddleware::class);
+    $app->pipe(UrlHelperMiddleware::class);
 
-// Pipe more middleware here that you want to execute on every request:
-// - bootstrapping
-// - pre-conditions
-// - modifications to outgoing responses
-//
-// Piped Middleware may be either callables or service names. Middleware may
-// also be passed as an array; each item in the array must resolve to
-// middleware eventually (i.e., callable or service name).
-//
-// Middleware can be attached to specific paths, allowing you to mix and match
-// applications under a common domain.  The handlers in each middleware
-// attached this way will see a URI with the MATCHED PATH SEGMENT REMOVED!!!
-//
-// - $app->pipe('/api', $apiMiddleware);
-// - $app->pipe('/docs', $apiDocMiddleware);
-// - $app->pipe('/files', $filesMiddleware);
+    // Add more middleware here that needs to introspect the routing results; this
+    // might include:
+    //
+    // - route-based authentication
+    // - route-based validation
+    // - etc.
 
-// Register the routing middleware in the middleware pipeline
-$app->pipe(PathBasedRoutingMiddleware::class);
-$app->pipe(ImplicitHeadMiddleware::class);
-$app->pipe(ImplicitOptionsMiddleware::class);
-$app->pipe(UrlHelperMiddleware::class);
+    // Register the dispatch middleware in the middleware pipeline
+    $app->pipe(DispatchMiddleware::class);
 
-// Add more middleware here that needs to introspect the routing results; this
-// might include:
-//
-// - route-based authentication
-// - route-based validation
-// - etc.
-
-// Register the dispatch middleware in the middleware pipeline
-$app->pipe(DispatchMiddleware::class);
-
-// At this point, if no Response is returned by any middleware, the
-// NotFoundMiddleware kicks in; alternately, you can provide other fallback
-// middleware to execute.
-$app->pipe(NotFoundMiddleware::class);
+    // At this point, if no Response is returned by any middleware, the
+    // NotFoundMiddleware kicks in; alternately, you can provide other fallback
+    // middleware to execute.
+    $app->pipe(NotFoundMiddleware::class);
+}

--- a/public/index.php
+++ b/public/index.php
@@ -19,11 +19,12 @@ require 'vendor/autoload.php';
 
     /** @var \Zend\Expressive\Application $app */
     $app = $container->get(\Zend\Expressive\Application::class);
+    $factory = $container->get(\Zend\Expressive\MiddlewareFactory::class);
 
-    // Import programmatic/declarative middleware pipeline and routing
+    // Execute programmatic/declarative middleware pipeline and routing
     // configuration statements
-    require 'config/pipeline.php';
-    require 'config/routes.php';
+    (require 'config/pipeline.php')($app, $factory, $container);
+    (require 'config/routes.php')($app, $factory, $container);
 
     $app->run();
 })();

--- a/src/ExpressiveInstaller/Resources/config/routes-full.php
+++ b/src/ExpressiveInstaller/Resources/config/routes-full.php
@@ -1,4 +1,11 @@
 <?php
+
+declare(strict_types=1);
+
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Application;
+use Zend\Expressive\MiddlewareFactory;
+
 /**
  * Setup routes with a single request method:
  *
@@ -25,10 +32,7 @@
  *     'contact'
  * );
  */
-
-declare(strict_types=1);
-
-/** @var \Zend\Expressive\Application $app */
-
-$app->get('/', App\Action\HomePageAction::class, 'home');
-$app->get('/api/ping', App\Action\PingAction::class, 'api.ping');
+return function (Application $app, MiddlewareFactory $factory, ContainerInterface $container) : void {
+    $app->get('/', App\Action\HomePageAction::class, 'home');
+    $app->get('/api/ping', App\Action\PingAction::class, 'api.ping');
+};

--- a/src/ExpressiveInstaller/Resources/config/routes-minimal.php
+++ b/src/ExpressiveInstaller/Resources/config/routes-minimal.php
@@ -1,4 +1,11 @@
 <?php
+
+declare(strict_types=1);
+
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Application;
+use Zend\Expressive\MiddlewareFactory;
+
 /**
  * Setup routes with a single request method:
  *
@@ -12,7 +19,5 @@
  *
  * $app->route('/contact', App\Action\ContactAction::class, ['GET', 'POST', ...], 'contact');
  */
-
-declare(strict_types=1);
-
-/** @var \Zend\Expressive\Application $app */
+return function (Application $app, MiddlewareFactory $factory, ContainerInterface $container) : void {
+};


### PR DESCRIPTION
This patch implements an idea [proposed by @Xerkus](https://github.com/zendframework/zend-expressive/pull/543#issuecomment-361419425): having the `pipeline.php` and `routes.php` files return _closures_, and updating `public/index.php` to capitalize on that in order to pass in arguments.

In this particular case, we pass the application, middleware factory, and PSR-11 container instances as arguments. This provides developers with all the tools they should need in order to create the pipeline and/or routes.

In essence, each file has the following statement:

```php
return function (Application $app, MiddlewareFactory $factory, ContainerInterface $container) : void {
};
```

This allows such things as:

- Using the `Zend\Stratigility\host()` utility:

  ```php
  $app->pipe(host('api.example.com', $factory->prepare(ApiAuthenticationMiddleware::class)));
  ```

- Selectively enabling or disabling middleware:

  ```php
  $config = $container->get('config');
  if (isset($config['debug'])) {
      $app->pipe(DebugMiddleware::class);
  }
  ```