### PR TITLE
Refactor "Actions" to request handlers

### DIFF
--- a/src/App/src/Handler/HomePageFactory.php
+++ b/src/App/src/Handler/HomePageFactory.php
@@ -2,22 +2,22 @@
 
 declare(strict_types=1);
 
-namespace App\Action;
+namespace App\Handler;
 
 use Psr\Container\ContainerInterface;
-use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
 
 class HomePageFactory
 {
-    public function __invoke(ContainerInterface $container) : MiddlewareInterface
+    public function __invoke(ContainerInterface $container) : RequestHandlerInterface
     {
         $router   = $container->get(RouterInterface::class);
         $template = $container->has(TemplateRendererInterface::class)
             ? $container->get(TemplateRendererInterface::class)
             : null;
 
-        return new HomePageAction($router, $template);
+        return new HomePageHandler($router, $template);
     }
 }

--- a/src/App/src/Handler/HomePageHandler.php
+++ b/src/App/src/Handler/HomePageHandler.php
@@ -2,11 +2,10 @@
 
 declare(strict_types=1);
 
-namespace App\Action;
+namespace App\Handler;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Diactoros\Response\HtmlResponse;
 use Zend\Diactoros\Response\JsonResponse;
@@ -16,7 +15,7 @@ use Zend\Expressive\Template;
 use Zend\Expressive\Twig\TwigRenderer;
 use Zend\Expressive\ZendView\ZendViewRenderer;
 
-class HomePageAction implements MiddlewareInterface
+class HomePageHandler implements RequestHandlerInterface
 {
     private $router;
 
@@ -28,7 +27,7 @@ class HomePageAction implements MiddlewareInterface
         $this->template = $template;
     }
 
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         if (! $this->template) {
             return new JsonResponse([

--- a/src/App/src/Handler/PingHandler.php
+++ b/src/App/src/Handler/PingHandler.php
@@ -2,17 +2,16 @@
 
 declare(strict_types=1);
 
-namespace App\Action;
+namespace App\Handler;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Diactoros\Response\JsonResponse;
 
-class PingAction implements MiddlewareInterface
+class PingHandler implements RequestHandlerInterface
 {
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         return new JsonResponse(['ack' => time()]);
     }

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -294,7 +294,7 @@ class OptionalPackages
             case self::INSTALL_FLAT:
                 // Re-arrange files into a flat structure.
                 $this->recursiveRmdir($this->projectRoot . '/src/App/templates');
-                rename($this->projectRoot . '/src/App/src/Action', $this->projectRoot . '/src/App/Action');
+                rename($this->projectRoot . '/src/App/src/Handler', $this->projectRoot . '/src/App/Handler');
                 $this->recursiveRmdir($this->projectRoot . '/src/App/src');
 
                 // Re-define autoloading rules

--- a/src/ExpressiveInstaller/Resources/config/routes-full.php
+++ b/src/ExpressiveInstaller/Resources/config/routes-full.php
@@ -9,30 +9,30 @@ use Zend\Expressive\MiddlewareFactory;
 /**
  * Setup routes with a single request method:
  *
- * $app->get('/', App\Action\HomePageAction::class, 'home');
- * $app->post('/album', App\Action\AlbumCreateAction::class, 'album.create');
- * $app->put('/album/:id', App\Action\AlbumUpdateAction::class, 'album.put');
- * $app->patch('/album/:id', App\Action\AlbumUpdateAction::class, 'album.patch');
- * $app->delete('/album/:id', App\Action\AlbumDeleteAction::class, 'album.delete');
+ * $app->get('/', App\Handler\HomePageHandler::class, 'home');
+ * $app->post('/album', App\Handler\AlbumCreateHandler::class, 'album.create');
+ * $app->put('/album/:id', App\Handler\AlbumUpdateHandler::class, 'album.put');
+ * $app->patch('/album/:id', App\Handler\AlbumUpdateHandler::class, 'album.patch');
+ * $app->delete('/album/:id', App\Handler\AlbumDeleteHandler::class, 'album.delete');
  *
  * Or with multiple request methods:
  *
- * $app->route('/contact', App\Action\ContactAction::class, ['GET', 'POST', ...], 'contact');
+ * $app->route('/contact', App\Handler\ContactHandler::class, ['GET', 'POST', ...], 'contact');
  *
  * Or handling all request methods:
  *
- * $app->route('/contact', App\Action\ContactAction::class)->setName('contact');
+ * $app->route('/contact', App\Handler\ContactHandler::class)->setName('contact');
  *
  * or:
  *
  * $app->route(
  *     '/contact',
- *     App\Action\ContactAction::class,
+ *     App\Handler\ContactHandler::class,
  *     Zend\Expressive\Router\Route::HTTP_METHOD_ANY,
  *     'contact'
  * );
  */
 return function (Application $app, MiddlewareFactory $factory, ContainerInterface $container) : void {
-    $app->get('/', App\Action\HomePageAction::class, 'home');
-    $app->get('/api/ping', App\Action\PingAction::class, 'api.ping');
+    $app->get('/', App\Handler\HomePageHandler::class, 'home');
+    $app->get('/api/ping', App\Handler\PingHandler::class, 'api.ping');
 };

--- a/src/ExpressiveInstaller/Resources/config/routes-minimal.php
+++ b/src/ExpressiveInstaller/Resources/config/routes-minimal.php
@@ -9,15 +9,15 @@ use Zend\Expressive\MiddlewareFactory;
 /**
  * Setup routes with a single request method:
  *
- * $app->get('/', App\Action\HomePageAction::class, 'home');
- * $app->post('/album', App\Action\AlbumCreateAction::class, 'album.create');
- * $app->put('/album/:id', App\Action\AlbumUpdateAction::class, 'album.put');
- * $app->patch('/album/:id', App\Action\AlbumUpdateAction::class, 'album.patch');
- * $app->delete('/album/:id', App\Action\AlbumDeleteAction::class, 'album.delete');
+ * $app->get('/', App\Handler\HomePageHandler::class, 'home');
+ * $app->post('/album', App\Handler\AlbumCreateHandler::class, 'album.create');
+ * $app->put('/album/:id', App\Handler\AlbumUpdateHandler::class, 'album.put');
+ * $app->patch('/album/:id', App\Handler\AlbumUpdateHandler::class, 'album.patch');
+ * $app->delete('/album/:id', App\Handler\AlbumDeleteHandler::class, 'album.delete');
  *
  * Or with multiple request methods:
  *
- * $app->route('/contact', App\Action\ContactAction::class, ['GET', 'POST', ...], 'contact');
+ * $app->route('/contact', App\Handler\ContactHandler::class, ['GET', 'POST', ...], 'contact');
  */
 return function (Application $app, MiddlewareFactory $factory, ContainerInterface $container) : void {
 };

--- a/src/ExpressiveInstaller/Resources/src/ConfigProvider.flat.php
+++ b/src/ExpressiveInstaller/Resources/src/ConfigProvider.flat.php
@@ -34,10 +34,10 @@ class ConfigProvider
     {
         return [
             'invokables' => [
-                Action\PingAction::class => Action\PingAction::class,
+                Handler\PingHandler::class => Handler\PingHandler::class,
             ],
             'factories'  => [
-                Action\HomePageAction::class => Action\HomePageFactory::class,
+                Handler\HomePageHandler::class => Handler\HomePageFactory::class,
             ],
         ];
     }

--- a/src/ExpressiveInstaller/Resources/src/ConfigProvider.modular.php
+++ b/src/ExpressiveInstaller/Resources/src/ConfigProvider.modular.php
@@ -34,10 +34,10 @@ class ConfigProvider
     {
         return [
             'invokables' => [
-                Action\PingAction::class => Action\PingAction::class,
+                Handler\PingHandler::class => Handler\PingHandler::class,
             ],
             'factories'  => [
-                Action\HomePageAction::class => Action\HomePageFactory::class,
+                Handler\HomePageHandler::class => Handler\HomePageFactory::class,
             ],
         ];
     }

--- a/test/AppTest/Handler/HomePageFactoryTest.php
+++ b/test/AppTest/Handler/HomePageFactoryTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace AppTest\Action;
+namespace AppTest\Handler;
 
-use App\Action\HomePageAction;
-use App\Action\HomePageFactory;
+use App\Handler\HomePageFactory;
+use App\Handler\HomePageHandler;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Zend\Expressive\Router\RouterInterface;
@@ -33,21 +33,20 @@ class HomePageFactoryTest extends TestCase
 
         $homePage = $factory($this->container->reveal());
 
-        $this->assertInstanceOf(HomePageAction::class, $homePage);
+        $this->assertInstanceOf(HomePageHandler::class, $homePage);
     }
 
     public function testFactoryWithTemplate()
     {
-        $factory = new HomePageFactory();
         $this->container->has(TemplateRendererInterface::class)->willReturn(true);
         $this->container
             ->get(TemplateRendererInterface::class)
             ->willReturn($this->prophesize(TemplateRendererInterface::class));
 
-        $this->assertInstanceOf(HomePageFactory::class, $factory);
+        $factory = new HomePageFactory();
 
         $homePage = $factory($this->container->reveal());
 
-        $this->assertInstanceOf(HomePageAction::class, $homePage);
+        $this->assertInstanceOf(HomePageHandler::class, $homePage);
     }
 }

--- a/test/AppTest/Handler/HomePageHandlerTest.php
+++ b/test/AppTest/Handler/HomePageHandlerTest.php
@@ -2,19 +2,18 @@
 
 declare(strict_types=1);
 
-namespace AppTest\Action;
+namespace AppTest\Handler;
 
-use App\Action\HomePageAction;
+use App\Handler\HomePageHandler;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Diactoros\Response\HtmlResponse;
 use Zend\Diactoros\Response\JsonResponse;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
 
-class HomePageActionTest extends TestCase
+class HomePageHandlerTest extends TestCase
 {
     /** @var RouterInterface */
     protected $router;
@@ -26,10 +25,9 @@ class HomePageActionTest extends TestCase
 
     public function testReturnsJsonResponseWhenNoTemplateRendererProvided()
     {
-        $homePage = new HomePageAction($this->router->reveal(), null);
-        $response = $homePage->process(
-            $this->prophesize(ServerRequestInterface::class)->reveal(),
-            $this->prophesize(RequestHandlerInterface::class)->reveal()
+        $homePage = new HomePageHandler($this->router->reveal(), null);
+        $response = $homePage->handle(
+            $this->prophesize(ServerRequestInterface::class)->reveal()
         );
 
         $this->assertInstanceOf(JsonResponse::class, $response);
@@ -42,11 +40,10 @@ class HomePageActionTest extends TestCase
             ->render('app::home-page', Argument::type('array'))
             ->willReturn('');
 
-        $homePage = new HomePageAction($this->router->reveal(), $renderer->reveal());
+        $homePage = new HomePageHandler($this->router->reveal(), $renderer->reveal());
 
-        $response = $homePage->process(
-            $this->prophesize(ServerRequestInterface::class)->reveal(),
-            $this->prophesize(RequestHandlerInterface::class)->reveal()
+        $response = $homePage->handle(
+            $this->prophesize(ServerRequestInterface::class)->reveal()
         );
 
         $this->assertInstanceOf(HtmlResponse::class, $response);

--- a/test/AppTest/Handler/PingHandlerTest.php
+++ b/test/AppTest/Handler/PingHandlerTest.php
@@ -2,22 +2,20 @@
 
 declare(strict_types=1);
 
-namespace AppTest\Action;
+namespace AppTest\Handler;
 
-use App\Action\PingAction;
+use App\Handler\PingHandler;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Diactoros\Response\JsonResponse;
 
-class PingActionTest extends TestCase
+class PingHandlerTest extends TestCase
 {
     public function testResponse()
     {
-        $pingAction = new PingAction();
-        $response = $pingAction->process(
-            $this->prophesize(ServerRequestInterface::class)->reveal(),
-            $this->prophesize(RequestHandlerInterface::class)->reveal()
+        $pingHandler = new PingHandler();
+        $response = $pingHandler->handle(
+            $this->prophesize(ServerRequestInterface::class)->reveal()
         );
 
         $json = json_decode((string) $response->getBody());

--- a/test/ExpressiveInstallerTest/ProjectSandboxTrait.php
+++ b/test/ExpressiveInstallerTest/ProjectSandboxTrait.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace ExpressiveInstallerTest;
 
-use App\Action\HomePageAction;
-use App\Action\PingAction;
+use App\Handler\HomePageHandler;
+use App\Handler\PingHandler;
 use DirectoryIterator;
 use ExpressiveInstaller\OptionalPackages;
 use PHPUnit\Framework\Assert;
@@ -222,12 +222,12 @@ trait ProjectSandboxTrait
         $app->pipe(DispatchMiddleware::class);
         $app->pipe(NotFoundMiddleware::class);
 
-        if ($setupRoutes === true && $container->has(HomePageAction::class)) {
-            $app->get('/', HomePageAction::class, 'home');
+        if ($setupRoutes === true && $container->has(HomePageHandler::class)) {
+            $app->get('/', HomePageHandler::class, 'home');
         }
 
-        if ($setupRoutes === true && $container->has(PingAction::class)) {
-            $app->get('/api/ping', PingAction::class, 'api.ping');
+        if ($setupRoutes === true && $container->has(PingHandler::class)) {
+            $app->get('/api/ping', PingHandler::class, 'api.ping');
         }
 
         return $app->handle(

--- a/test/ExpressiveInstallerTest/RoutersTest.php
+++ b/test/ExpressiveInstallerTest/RoutersTest.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace ExpressiveInstallerTest;
 
-use App\Action\HomePageAction;
-use App\Action\PingAction;
+use App\Handler\HomePageHandler;
+use App\Handler\PingHandler;
 use ExpressiveInstaller\OptionalPackages;
 use Zend\Expressive\Application;
 use Zend\Expressive\Router;
@@ -26,13 +26,13 @@ class RoutersTest extends OptionalPackagesTestCase
         [
             'name'            => 'home',
             'path'            => '/',
-            'middleware'      => HomePageAction::class,
+            'middleware'      => HomePageHandler::class,
             'allowed_methods' => ['GET'],
         ],
         [
             'name'            => 'api.ping',
             'path'            => '/api/ping',
-            'middleware'      => PingAction::class,
+            'middleware'      => PingHandler::class,
             'allowed_methods' => ['GET'],
         ],
     ];


### PR DESCRIPTION
Since zend-expressive 3.0.0alpha2 and up support routing and piping to request handlers, we can adopt that practice and terminology for the shipped "middleware", which are actually handlers.