### PR TITLE
Whitelist all possible components installed by the installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 3.0.0alpha3 - TBD
+
+### Added
+
+- [#215](https://github.com/zendframework/zend-expressive-skeleton/pull/215)
+  adds packages to the component installer whitelist to prevent ConfigProvider 
+  prompts.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 3.0.0alpha2 - 2018-02-07
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "require": {
         "php": "^7.1",
         "roave/security-advisories": "dev-master",
-        "zendframework/zend-component-installer": "^2.0",
+        "zendframework/zend-component-installer": "^2.1",
         "zendframework/zend-config-aggregator": "^1.0",
         "zendframework/zend-expressive": "^3.0.0alpha5",
         "zendframework/zend-expressive-helpers": "^5.0.0alpha3",

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,19 @@
             "dev-master": "2.1.x-dev",
             "dev-develop": "2.2.x-dev",
             "dev-release-3.0.0": "3.0.x-dev"
+        },
+        "zf": {
+            "component-whitelist": [
+                "zendframework/zend-expressive",
+                "zendframework/zend-expressive-aurarouter",
+                "zendframework/zend-expressive-fastroute",
+                "zendframework/zend-expressive-helpers",
+                "zendframework/zend-expressive-platesrenderer",
+                "zendframework/zend-expressive-twigrenderer",
+                "zendframework/zend-expressive-zendrouter",
+                "zendframework/zend-expressive-zendviewrenderer",
+                "zendframework/zend-httphandlerrunner"
+            ]
         }
     },
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,7 @@
         "zf": {
             "component-whitelist": [
                 "zendframework/zend-expressive",
-                "zendframework/zend-expressive-aurarouter",
-                "zendframework/zend-expressive-fastroute",
                 "zendframework/zend-expressive-helpers",
-                "zendframework/zend-expressive-platesrenderer",
-                "zendframework/zend-expressive-twigrenderer",
-                "zendframework/zend-expressive-zendrouter",
-                "zendframework/zend-expressive-zendviewrenderer",
                 "zendframework/zend-httphandlerrunner"
             ]
         }

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -4,18 +4,60 @@ declare(strict_types=1);
 
 return [
     'packages' => [
-        'filp/whoops'                                    => '^2.1.12',
-        'jsoumelidis/zend-sf-di-config'                  => '^0.1',
-        'northwoods/container'                           => '^1.2',
-        'zendframework/zend-auradi-config'               => '^1.0.0-dev',
-        'zendframework/zend-expressive-aurarouter'       => '^3.0.0alpha2 || ^3.0',
-        'zendframework/zend-expressive-fastroute'        => '^3.0.0alpha1 || ^3.0',
-        'zendframework/zend-expressive-platesrenderer'   => '^2.0.0alpha1 || ^2.0',
-        'zendframework/zend-expressive-twigrenderer'     => '^2.0.0alpha1 || ^2.0',
-        'zendframework/zend-expressive-zendrouter'       => '^3.0.0alpha2 || ^3.0',
-        'zendframework/zend-expressive-zendviewrenderer' => '^2.0.0alpha2 || ^2.0',
-        'zendframework/zend-pimple-config'               => '^1.0.0-dev',
-        'zendframework/zend-servicemanager'              => '^3.3',
+        'filp/whoops' => [
+            'version' => '^2.1.12',
+        ],
+        'jsoumelidis/zend-sf-di-config' => [
+            'version' => '^0.1',
+        ],
+        'northwoods/container' => [
+            'version' => '^1.2',
+        ],
+        'zendframework/zend-auradi-config' => [
+            'version' => '^1.0.0-dev',
+        ],
+        'zendframework/zend-expressive-aurarouter' => [
+            'version'   => '^3.0.0alpha2 || ^3.0',
+            'whitelist' => [
+                'zendframework/zend-expressive-aurarouter'
+            ]
+        ],
+        'zendframework/zend-expressive-fastroute' => [
+            'version'   => '^3.0.0alpha1 || ^3.0',
+            'whitelist' => [
+                'zendframework/zend-expressive-fastroute'
+            ]
+        ],
+        'zendframework/zend-expressive-platesrenderer' => [
+            'version'   => '^2.0.0alpha1 || ^2.0',
+            'whitelist' => [
+                'zendframework/zend-expressive-platesrenderer'
+            ]
+        ],
+        'zendframework/zend-expressive-twigrenderer' => [
+            'version'   => '^2.0.0alpha1 || ^2.0',
+            'whitelist' => [
+                'zendframework/zend-expressive-twigrenderer'
+            ]
+        ],
+        'zendframework/zend-expressive-zendrouter' => [
+            'version'   => '^3.0.0alpha2 || ^3.0',
+            'whitelist' => [
+                'zendframework/zend-expressive-zendrouter'
+            ]
+        ],
+        'zendframework/zend-expressive-zendviewrenderer' => [
+            'version'   => '^2.0.0alpha2 || ^2.0',
+            'whitelist' => [
+                'zendframework/zend-expressive-zendviewrenderer'
+            ]
+        ],
+        'zendframework/zend-pimple-config' => [
+            'version' => '^1.0.0-dev',
+        ],
+        'zendframework/zend-servicemanager' => [
+            'version' => '^3.3',
+        ],
     ],
 
     'require-dev' => [

--- a/test/ExpressiveInstallerTest/OptionalPackagesTestCase.php
+++ b/test/ExpressiveInstallerTest/OptionalPackagesTestCase.php
@@ -117,6 +117,27 @@ abstract class OptionalPackagesTestCase extends TestCase
         }
     }
 
+    /**
+     * Assert that the installer contains a specification for the package.
+     *
+     * @throws AssertionFailedError
+     */
+    public static function assertWhitelisted(string $package, OptionalPackages $installer, string $message = null)
+    {
+        $message = $message ?: sprintf('Failed asserting that package "%s" is whitelisted in composer.json', $package);
+        $found   = false;
+
+        $r = new ReflectionProperty($installer, 'composerDefinition');
+        $r->setAccessible(true);
+        $whitelist = $r->getValue($installer)['extra']['zf']['component-whitelist'];
+
+        if (in_array($package, $whitelist)) {
+            $found = true;
+        }
+
+        self::assertThat($found, self::isTrue(), $message);
+    }
+
     protected function setUp()
     {
         $this->packageRoot = realpath(__DIR__ . '/../../');

--- a/test/ExpressiveInstallerTest/ProcessAnswersTest.php
+++ b/test/ExpressiveInstallerTest/ProcessAnswersTest.php
@@ -112,4 +112,23 @@ class ProcessAnswersTest extends OptionalPackagesTestCase
         $this->assertFileNotExists($this->projectRoot . '/config/container.php');
         $this->assertPackage('league/container', $this->installer);
     }
+
+    public function testPackagesAreAddedToWhitelist()
+    {
+        // Prepare the installer
+        $this->installer->removeDevDependencies();
+
+        // @codingStandardsIgnoreStart
+        $this->io->write(Argument::containingString('Adding package <info>zendframework/zend-expressive-zendviewrenderer</info>'))->shouldBeCalled();
+        // @codingStandardsIgnoreEnd
+
+        $config   = $this->getInstallerConfig($this->installer);
+        $question = $config['questions']['template-engine'];
+        $answer   = 3;
+        $result   = $this->installer->processAnswer($question, $answer);
+
+        $this->assertTrue($result);
+        $this->assertPackage('zendframework/zend-expressive-zendviewrenderer', $this->installer);
+        $this->assertWhitelisted('zendframework/zend-expressive-zendviewrenderer', $this->installer);
+    }
 }

--- a/test/ExpressiveInstallerTest/UpdateRootPackageTest.php
+++ b/test/ExpressiveInstallerTest/UpdateRootPackageTest.php
@@ -54,6 +54,7 @@ class UpdateRootPackageTest extends OptionalPackagesTestCase
         $this->rootPackage->setStabilityFlags($this->changes['stabilityFlags'])->shouldBeCalled();
         $this->rootPackage->setAutoload($this->changes['composerDefinition']['autoload'])->shouldBeCalled();
         $this->rootPackage->setDevAutoload($this->changes['composerDefinition']['autoload-dev'])->shouldBeCalled();
+        $this->rootPackage->setExtra([])->shouldBeCalled();
 
         $installer->updateRootPackage();
     }


### PR DESCRIPTION
Add packages to the zend-component-installer whitelist to allow silent installation without the inject package prompt. It pre-whitelists packages in composer.json which are installed by default and also whitelists selected packages and possible dependencies.

Depends on zendframework/zend-component-installer#48
Related zendframework/zend-component-installer#48

Closes #207
Closes #204