### PR TITLE
Fix the composer serve command for PHP 7.1.14+ and PHP 7.2.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ After choosing and installing the packages you want, go to the
 $ composer run --timeout=0 serve
 ```
 
-You can then browse to http://localhost:8080.
+You can then browse to http://localhost:8080. On PHP versions prior to 7.1.14 
+and 7.2.2 this command might not work and you need to start the 
+[built-in web server](http://php.net/manual/en/features.commandline.webserver.php) 
+yourself.
 
 > ### Setting a timeout
 >

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
         "clear-config-cache": "php bin/clear-config-cache.php",
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
-        "serve": "php -S 0.0.0.0:8080 -t public/ index.php",
+        "serve": "php -S 0.0.0.0:8080 -t public/",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     }


### PR DESCRIPTION
This PR fixes the `composer serve` command as discussed in #196.

Closes #196