### PR TITLE
Reverts usage of ROUTE_MIDDLEWARE constant

### DIFF
--- a/config/pipeline.php
+++ b/config/pipeline.php
@@ -9,11 +9,11 @@ use Zend\Expressive\Helper\ServerUrlMiddleware;
 use Zend\Expressive\Helper\UrlHelperMiddleware;
 use Zend\Expressive\MiddlewareFactory;
 use Zend\Expressive\Router\Middleware\DispatchMiddleware;
+use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware;
 use Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Router\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Router\Middleware\MethodNotAllowedMiddleware;
 use Zend\Stratigility\Middleware\ErrorHandler;
-use const Zend\Expressive\ROUTE_MIDDLEWARE;
 
 /**
  * Setup middleware pipeline:
@@ -42,10 +42,17 @@ return function (Application $app, MiddlewareFactory $factory, ContainerInterfac
     // - $app->pipe('/files', $filesMiddleware);
 
     // Register the routing middleware in the middleware pipeline
-    $app->pipe(ROUTE_MIDDLEWARE);
+    $app->pipe(PathBasedRoutingMiddleware::class);
+
+    // The following handle routing failures for common conditions:
+    // - method not allowed
+    // - HEAD request but no routes answer that method
+    // - OPTIONS request but no routes answer that method
     $app->pipe(MethodNotAllowedMiddleware::class);
     $app->pipe(ImplicitHeadMiddleware::class);
     $app->pipe(ImplicitOptionsMiddleware::class);
+
+    // Seed the UrlHelper with the routing results:
     $app->pipe(UrlHelperMiddleware::class);
 
     // Add more middleware here that needs to introspect the routing results; this

--- a/test/ExpressiveInstallerTest/ProjectSandboxTrait.php
+++ b/test/ExpressiveInstallerTest/ProjectSandboxTrait.php
@@ -22,11 +22,11 @@ use Zend\Expressive\Handler\NotFoundHandler;
 use Zend\Expressive\Helper\ServerUrlMiddleware;
 use Zend\Expressive\Helper\UrlHelperMiddleware;
 use Zend\Expressive\Router\Middleware\DispatchMiddleware;
+use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware;
 use Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Router\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Router\Middleware\MethodNotAllowedMiddleware;
 use Zend\Stratigility\Middleware\ErrorHandler;
-use const Zend\Expressive\ROUTE_MIDDLEWARE;
 
 trait ProjectSandboxTrait
 {
@@ -215,7 +215,7 @@ trait ProjectSandboxTrait
         // Import programmatic/declarative middleware pipeline and routing configuration statements
         $app->pipe(ErrorHandler::class);
         $app->pipe(ServerUrlMiddleware::class);
-        $app->pipe(ROUTE_MIDDLEWARE);
+        $app->pipe(PathBasedRoutingMiddleware::class);
         $app->pipe(MethodNotAllowedMiddleware::class);
         $app->pipe(ImplicitHeadMiddleware::class);
         $app->pipe(ImplicitOptionsMiddleware::class);


### PR DESCRIPTION
This patch follows on zendframework/zend-expressive#559, and modifies the pipeline to directly refer to the `PathBasedRoutingMiddleware` instead of using the `ROUTE_MIDDLEWARE` constant. It's better and faster to use the canonical name, and the old name (to which the constant resolves) is an alias for purposes of aiding those upgrading from v2; since aliases resolve to the same instance as the canonical service, this remains backwards compatible.