### PR TITLE
rename HomePageFactory to HomePageHandlerFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this project will be documented in this file, in reverse 
   and [zend-expressive 3.0.0alpha7](https://github.com/zendframework/zend-expressive/tree/3.0.0alpha6)
   changelogs.
 
+- [#226](https://github.com/zendframework/zend-expressive-skeleton/pull/226)
+  updates factory class name from `App\Handler\HomePageFactory` to `App\Handler\HomePageHandlerFactory` to reflect the class handler.
+
 ### Deprecated
 
 - Nothing.

--- a/src/App/src/Handler/HomePageHandlerFactory.php
+++ b/src/App/src/Handler/HomePageHandlerFactory.php
@@ -9,7 +9,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
 
-class HomePageFactory
+class HomePageHandlerFactory
 {
     public function __invoke(ContainerInterface $container) : RequestHandlerInterface
     {

--- a/src/ExpressiveInstaller/Resources/src/ConfigProvider.flat.php
+++ b/src/ExpressiveInstaller/Resources/src/ConfigProvider.flat.php
@@ -36,7 +36,7 @@ class ConfigProvider
                 Handler\PingHandler::class => Handler\PingHandler::class,
             ],
             'factories'  => [
-                Handler\HomePageHandler::class => Handler\HomePageFactory::class,
+                Handler\HomePageHandler::class => Handler\HomePageHandlerFactory::class,
             ],
         ];
     }

--- a/src/ExpressiveInstaller/Resources/src/ConfigProvider.modular.php
+++ b/src/ExpressiveInstaller/Resources/src/ConfigProvider.modular.php
@@ -36,7 +36,7 @@ class ConfigProvider
                 Handler\PingHandler::class => Handler\PingHandler::class,
             ],
             'factories'  => [
-                Handler\HomePageHandler::class => Handler\HomePageFactory::class,
+                Handler\HomePageHandler::class => Handler\HomePageHandlerFactory::class,
             ],
         ];
     }

--- a/test/AppTest/Handler/HomePageFactoryTest.php
+++ b/test/AppTest/Handler/HomePageFactoryTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace AppTest\Handler;
 
-use App\Handler\HomePageFactory;
+use App\Handler\HomePageHandlerFactory;
 use App\Handler\HomePageHandler;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
 
-class HomePageFactoryTest extends TestCase
+class HomePageHandlerFactoryTest extends TestCase
 {
     /** @var ContainerInterface */
     protected $container;
@@ -26,10 +26,10 @@ class HomePageFactoryTest extends TestCase
 
     public function testFactoryWithoutTemplate()
     {
-        $factory = new HomePageFactory();
+        $factory = new HomePageHandlerFactory();
         $this->container->has(TemplateRendererInterface::class)->willReturn(false);
 
-        $this->assertInstanceOf(HomePageFactory::class, $factory);
+        $this->assertInstanceOf(HomePageHandlerFactory::class, $factory);
 
         $homePage = $factory($this->container->reveal());
 
@@ -43,7 +43,7 @@ class HomePageFactoryTest extends TestCase
             ->get(TemplateRendererInterface::class)
             ->willReturn($this->prophesize(TemplateRendererInterface::class));
 
-        $factory = new HomePageFactory();
+        $factory = new HomePageHandlerFactory();
 
         $homePage = $factory($this->container->reveal());
 


### PR DESCRIPTION
As the factory is used to create the "HomePageHandler" with "Handler" suffix, I think it is better to have factory named "HomePageHandlerFactory" with "Handler" inside it.