### PR TITLE
Proposal: add phpstan for installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       env:
         - DEPS=latest
         - CS_CHECK=true
-        - PHPSTAN=true
+        - PHPSTAN_CHECK=true
         - TEST_COVERAGE=true
     - php: 7.2
       env:
@@ -41,7 +41,7 @@ install:
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
-  - if [[ $PHPSTAN == 'true' ]]; then vendor/bin/phpstan analyze -l max -c ./phpstan.installer.neon ./src ./config ; fi
+  - if [[ $PHPSTAN_CHECK == 'true' ]]; then vendor/bin/phpstan analyze -l max -c ./phpstan.installer.neon ./src ./config ; fi
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry vendor/bin/php-coveralls -v ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
       env:
         - DEPS=latest
         - CS_CHECK=true
+        - PHPSTAN=true
         - TEST_COVERAGE=true
     - php: 7.2
       env:
@@ -40,6 +41,7 @@ install:
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
+  - if [[ $PHPSTAN == 'true' ]]; then phpstan analyze -l max -c ./phpstan.installer.neon ./src ./config ; fi
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry vendor/bin/php-coveralls -v ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
-  - if [[ $PHPSTAN == 'true' ]]; then phpstan analyze -l max -c ./phpstan.installer.neon ./src ./config ; fi
+  - if [[ $PHPSTAN == 'true' ]]; then vendor/bin/phpstan analyze -l max -c ./phpstan.installer.neon ./src ./config ; fi
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry vendor/bin/php-coveralls -v ; fi

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,8 @@
         "jsoumelidis/zend-sf-di-config": "^0.1",
         "mikey179/vfsstream": "^1.6.5",
         "northwoods/container": "^1.2",
+        "phpstan/phpstan": "^0.9.2",
+        "phpstan/phpstan-strict-rules": "^0.9.0",
         "phpunit/phpunit": "^7.0",
         "squizlabs/php_codesniffer": "^2.9.1",
         "zendframework/zend-auradi-config": "^1.0.0alpha1",

--- a/phpstan.installer.neon
+++ b/phpstan.installer.neon
@@ -1,0 +1,14 @@
+# zend-expressive-skeleton specific
+includes:
+	- vendor/phpstan/phpstan-strict-rules/rules.neon
+parameters:
+	fileExtensions:
+		# Standard php files and .dist config files
+		- php
+		- dist
+	excludes_analyse:
+		- src/ExpressiveInstaller/Resources/src/ConfigProvider.flat.php
+		- src/ExpressiveInstaller/Resources/src/ConfigProvider.modular.php
+	reportUnmatchedIgnoredErrors: true
+	ignoreErrors:
+		- '#Class App\\ConfigProvider not found#'

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -66,6 +66,7 @@ class OptionalPackages
         'CONDUCT.md',
         'CONTRIBUTING.md',
         'phpcs.xml',
+        'phpstan.installer.neon',
         'src/App/templates/.gitkeep',
     ];
 
@@ -108,6 +109,8 @@ class OptionalPackages
         'jsoumelidis/zend-sf-di-config',
         'mikey179/vfsstream',
         'northwoods/container',
+        "phpstan/phpstan",
+        "phpstan/phpstan-strict-rules",
         'zendframework/zend-auradi-config',
         'zendframework/zend-coding-standard',
         'zendframework/zend-expressive-aurarouter',

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -476,7 +476,7 @@ class OptionalPackages
         $link = new Link('__root__', $packageName, $constraint, 'requires', $packageVersion);
 
         // Add package to the root package and composer.json requirements
-        if (in_array($packageName, $this->config['require-dev'])) {
+        if (in_array($packageName, $this->config['require-dev'], true)) {
             unset($this->composerDefinition['require'][$packageName]);
             unset($this->composerRequires[$packageName]);
 
@@ -508,7 +508,7 @@ class OptionalPackages
 
         // Whitelist packages for the component installer
         foreach ($whitelist as $package) {
-            if (! in_array($package, $this->composerDefinition['extra']['zf']['component-whitelist'])) {
+            if (! in_array($package, $this->composerDefinition['extra']['zf']['component-whitelist'], true)) {
                 $this->composerDefinition['extra']['zf']['component-whitelist'][] = $package;
                 $this->io->write(sprintf('  - Whitelist package <info>%s</info>', $package));
             }
@@ -646,7 +646,7 @@ class OptionalPackages
                 $this->io->write(sprintf('  - Searching for <info>%s:%s</info>', $packageName, $packageVersion));
 
                 $optionalPackage = $this->composer->getRepositoryManager()->findPackage($packageName, $packageVersion);
-                if (! $optionalPackage) {
+                if (null === $optionalPackage) {
                     $this->io->write(sprintf('<error>Package not found %s:%s</error>', $packageName, $packageVersion));
                     continue;
                 }


### PR DESCRIPTION
After having issues with previous alpha's (now fixed, see #220), why not benefit from phpstan to ensure the skeleton passes static analysis ? 

I think the skeleton should not be opinionated. So the changes I've made are only tested with travis (no composer scripts) and deps are removed after install. The drawback is that it's not totally accurate (tests does run prior to an actual installation).

So for now it's open for ideas... (travis build stages with real installs... ?).

*BTW, travis will probably stop to complaining after #229 is merged*