### PR TITLE
Add global config as implied by file provider in config/config.php

### DIFF
--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Global Configuration Override
+ *
+ * You can use this file for global application configurations,
+ * overriding configuration values from modules, etc.
+ * You would place values in here that are agnostic to the environment and not
+ * sensitive to security.
+ *
+ * @NOTE: In practice, this file will typically be INCLUDED in your source
+ * control, so do not include passwords or other sensitive information in this
+ * file. Those can be included in `local.php`
+ */
+return [
+    // ...
+];


### PR DESCRIPTION
Was very confused where are configs `autoload/local.php` is overriding coming fro,m so I could set up local development environment vs template in repository.
Couldn't find the original thing to override the way I am used to in MVC Skeleton, then noticed file provider is also looking for `global.php` which wasn't there so thought I would add it.