### PR TITLE
Add data/cache to gitkeep

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,2 +1,4 @@
 *
+!cache
+!cache/.gitkeep
 !.gitignore


### PR DESCRIPTION
Add data/cache to gitkeep to prevent checkout of project to different location from throwing non-existent directories warning.