### PR TITLE
 Convert questions to a string, fixes #243

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,8 +94,10 @@
         "expressive": "expressive --ansi",
         "check": [
             "@cs-check",
-            "@test"
+            "@test",
+            "@analyze"
         ],
+        "analyze": "phpstan analyze -l max -c ./phpstan.installer.neon ./src ./config",
         "clear-config-cache": "php bin/clear-config-cache.php",
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -251,7 +251,7 @@ class OptionalPackages
         ];
 
         while (true) {
-            $answer = $this->io->ask($query, '2');
+            $answer = $this->io->ask(implode($query), '2');
 
             switch (true) {
                 case ($answer === '1'):
@@ -621,7 +621,7 @@ class OptionalPackages
 
         while (true) {
             // Ask for user input
-            $answer = $this->io->ask($ask, (string) $defaultOption);
+            $answer = $this->io->ask(implode($ask), (string) $defaultOption);
 
             // Handle none of the options
             if ($answer === 'n' && $question['required'] !== true) {

--- a/test/ExpressiveInstallerTest/PromptForOptionalPackagesTest.php
+++ b/test/ExpressiveInstallerTest/PromptForOptionalPackagesTest.php
@@ -90,8 +90,16 @@ class PromptForOptionalPackagesTest extends OptionalPackagesTestCase
 
     public static function assertPromptText($expected, $argument)
     {
-        $argument = is_array($argument) ? array_shift($argument) : $argument;
-        $message = sprintf('Expected prompt not received: "%s"', $expected);
-        self::assertThat(false !== strpos($argument, $expected), self::isTrue(), $message);
+        self::assertInternalType(
+            'string',
+            $argument,
+            'Questions must be a string since symfony/console:4.0'
+        );
+
+        self::assertThat(
+            false !== strpos($argument, $expected),
+            self::isTrue(),
+            sprintf('Expected prompt not received: "%s"', $expected)
+        );
     }
 }

--- a/test/ExpressiveInstallerTest/RequestInstallTypeTest.php
+++ b/test/ExpressiveInstallerTest/RequestInstallTypeTest.php
@@ -78,7 +78,11 @@ class RequestInstallTypeTest extends OptionalPackagesTestCase
 
     public static function assertQueryPrompt($value)
     {
-        $value = is_array($value) ? array_shift($value) : $value;
+        self::assertInternalType(
+            'string',
+            $value,
+            'Questions must be a string since symfony/console:4.0'
+        );
 
         self::assertThat(
             false !== strpos($value, 'What type of installation would you like?'),


### PR DESCRIPTION
Since symfony/console 4 questions only accept a question string. Looking at its history, this was always the case and is wrong in the composer docblock.

see: https://github.com/symfony/console/blob/4.0/Question/Question.php#L37
see: https://github.com/composer/composer/blob/1.6/src/Composer/IO/IOInterface.php#L106