### PR TITLE
Upgrade Auryn container support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#251](https://github.com/zendframework/zend-expressive-skeleton/pull/251)
+  updates the minimum version of northwoods/container to version 3.0.0,
+  as that version now passes all DI container configuration compatibility tests.
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "filp/whoops": "^2.1.12",
         "jsoumelidis/zend-sf-di-config": "^0.3",
         "mikey179/vfsstream": "^1.6.5",
-        "northwoods/container": "^1.2",
+        "northwoods/container": "^3.0",
         "phpstan/phpstan": "^0.9.2",
         "phpstan/phpstan-strict-rules": "^0.9.0",
         "phpunit/phpunit": "^7.0.1",

--- a/src/ExpressiveInstaller/Resources/config/container-auryn.php
+++ b/src/ExpressiveInstaller/Resources/config/container-auryn.php
@@ -2,25 +2,10 @@
 
 declare(strict_types=1);
 
-use Northwoods\Container\Config;
-use Northwoods\Container\InjectorBuilder;
-use Psr\Container\ContainerInterface;
+use Northwoods\Container\Zend\ContainerFactory;
+use Northwoods\Container\Zend\Config;
 
-// Load configuration
-$config = require __DIR__ . '/config.php';
+$config = new Config(require __DIR__ . '/config.php');
+$factory = new ContainerFactory();
 
-$builder = new InjectorBuilder([
-    new Config\ContainerConfig(),
-    new Config\ServiceConfig($config['dependencies'] ?? []),
-]);
-
-/** @var \Auryn\Injector */
-$injector = $builder->build();
-
-$injector->share('config')->delegate('config', function () use ($config) : \ArrayObject {
-    // Auryn requires that all injections resolve to an object.
-    // Wrap the config array with an ArrayObject to appease the gods.
-    return new \ArrayObject($config);
-});
-
-return $injector->make(ContainerInterface::class);
+return $factory($config);

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -11,7 +11,7 @@ return [
             'version' => '^0.3',
         ],
         'northwoods/container' => [
-            'version' => '^1.2',
+            'version' => '^3.0',
         ],
         'zendframework/zend-auradi-config' => [
             'version' => '^1.0',


### PR DESCRIPTION
Improved support for `Auryn` as a compatible container.

Refs northwoods/container#12