### PR TITLE
Added Swoole config, if installed

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -23,7 +23,7 @@ $aggregator = new ConfigAggregator([
     // Swoole config to overwrite some services (if installed)
     class_exists(\Zend\Expressive\Swoole\ConfigProvider::class)
         ? \Zend\Expressive\Swoole\ConfigProvider::class
-        : null,
+        : function(){ return[]; },
 
     // Default App module config
     App\ConfigProvider::class,

--- a/config/config.php
+++ b/config/config.php
@@ -20,6 +20,11 @@ $aggregator = new ConfigAggregator([
     \Zend\Expressive\ConfigProvider::class,
     \Zend\Expressive\Router\ConfigProvider::class,
 
+    // Swoole config to overwrite some services (if installed)
+    class_exists(\Zend\Expressive\Swoole\ConfigProvider::class)
+        ? \Zend\Expressive\Swoole\ConfigProvider::class
+        : null,
+
     // Default App module config
     App\ConfigProvider::class,
 

--- a/phpstan.installer.neon
+++ b/phpstan.installer.neon
@@ -12,3 +12,4 @@ parameters:
 	reportUnmatchedIgnoredErrors: true
 	ignoreErrors:
 		- '#Class App\\ConfigProvider not found#'
+		- '#Class Zend\\Expressive\\Swoole\\ConfigProvider not found#'


### PR DESCRIPTION
This PR adds the support of [Swoole](https://www.swoole.co.uk/) overwriting some service configurations of [zend-expressive](https://github.com/zendframework/zend-expressive).
The configuration is injected via `Zend\Expressive\Swoole\ConfigProvider` if [zend-expressive-swoole](https://github.com/zendframework/zend-expressive-swoole) is installed.

This PR allows to execute Swoole without any change on `public/index.php`. We can just run the follows:
```bash
php public/index.php
```
To execute an Expressive application with Swoole.
