### PR TITLE
Add missing ObjectProphecy imports

### DIFF
--- a/test/AppTest/Handler/HomePageHandlerFactoryTest.php
+++ b/test/AppTest/Handler/HomePageHandlerFactoryTest.php
@@ -7,6 +7,7 @@ namespace AppTest\Handler;
 use App\Handler\HomePageHandler;
 use App\Handler\HomePageHandlerFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;

--- a/test/AppTest/Handler/HomePageHandlerTest.php
+++ b/test/AppTest/Handler/HomePageHandlerTest.php
@@ -7,6 +7,7 @@ namespace AppTest\Handler;
 use App\Handler\HomePageHandler;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\HtmlResponse;


### PR DESCRIPTION
When creating a fresh project using `composer create-project zendframework/zend-expressive-skeleton` two namespace imports in the PHPUnit tests are missing.

This has no functional impact but PHPStorm and other static analysis tools will complain.