### PR TITLE
Don't pass the requested name to the factory

### DIFF
--- a/test/AppTest/Handler/HomePageHandlerFactoryTest.php
+++ b/test/AppTest/Handler/HomePageHandlerFactoryTest.php
@@ -32,7 +32,7 @@ class HomePageHandlerFactoryTest extends TestCase
 
         $this->assertInstanceOf(HomePageHandlerFactory::class, $factory);
 
-        $homePage = $factory($this->container->reveal(), null, get_class($this->container->reveal()));
+        $homePage = $factory($this->container->reveal());
 
         $this->assertInstanceOf(HomePageHandler::class, $homePage);
     }
@@ -46,7 +46,7 @@ class HomePageHandlerFactoryTest extends TestCase
 
         $factory = new HomePageHandlerFactory();
 
-        $homePage = $factory($this->container->reveal(), null, get_class($this->container->reveal()));
+        $homePage = $factory($this->container->reveal());
 
         $this->assertInstanceOf(HomePageHandler::class, $homePage);
     }


### PR DESCRIPTION
This PR removes the requested name being passed to the factory. The requested name is not used and it was wrong anyway. It should have been the FQN of the handler and not the container. Also it should be
passed as the second argument as the third one is for options.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a `CHANGELOG.md` entry for the fix.