### PR TITLE
Allow Diactoros 2.0 as an option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "php": "^7.1",
         "zendframework/zend-component-installer": "^2.1.1",
         "zendframework/zend-config-aggregator": "^1.0",
-        "zendframework/zend-diactoros": "^1.7.1",
+        "zendframework/zend-diactoros": "^1.7.1 || ^2.0",
         "zendframework/zend-expressive": "^3.0.1",
         "zendframework/zend-expressive-helpers": "^5.0",
         "zendframework/zend-stdlib": "^3.1"


### PR DESCRIPTION
This patch modifies the constraint for zend-diactoros to allow both `^1.7` and `^2.0` versions. At this time, tests pass against both versions, meaning it is already compatible.