### PR TITLE
Remove phpstan leftovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#264](https://github.com/zendframework/zend-expressive-skeleton/pull/264) removes phpstan leftovers.
 
 ## 3.2.0 - 2018-09-27
 

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -400,7 +400,8 @@ class OptionalPackages
 
         // Remove phpstan completely
         $this->composerDefinition['scripts']['check'] = array_diff(
-            $this->composerDefinition['scripts']['check'], ['@analyze']
+            $this->composerDefinition['scripts']['check'],
+            ['@analyze']
         );
         unset($this->composerDefinition['scripts']['analyze']);
     }

--- a/src/ExpressiveInstaller/OptionalPackages.php
+++ b/src/ExpressiveInstaller/OptionalPackages.php
@@ -397,6 +397,12 @@ class OptionalPackages
         // Remove installer scripts
         unset($this->composerDefinition['scripts']['pre-update-cmd']);
         unset($this->composerDefinition['scripts']['pre-install-cmd']);
+
+        // Remove phpstan completely
+        $this->composerDefinition['scripts']['check'] = array_diff(
+            $this->composerDefinition['scripts']['check'], ['@analyze']
+        );
+        unset($this->composerDefinition['scripts']['analyze']);
     }
 
     /**

--- a/test/ExpressiveInstallerTest/RemoveInstallerTest.php
+++ b/test/ExpressiveInstallerTest/RemoveInstallerTest.php
@@ -49,5 +49,7 @@ class RemoveInstallerTest extends OptionalPackagesTestCase
         $this->assertFalse(isset($composer['extra']['optional-packages']));
         $this->assertFalse(isset($composer['scripts']['pre-install-cmd']));
         $this->assertFalse(isset($composer['scripts']['pre-update-cmd']));
+        $this->assertFalse(isset($composer['scripts']['check']['@analyze']));
+        $this->assertFalse(isset($composer['scripts']['analyze']));
     }
 }


### PR DESCRIPTION
This PR removes the phpstan leftovers from composer.

Fixes #261 
Fixes #263 

- [x] Are you fixing a bug?
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.