### PR TITLE
Updates zend phpdi to v4 [BC]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     },
     "require-dev": {
         "composer/composer": "^1.5",
-        "elie29/zend-phpdi-config": "^3.0",
+        "elie29/zend-phpdi-config": "^4.0",
         "filp/whoops": "^2.1.12",
         "jsoumelidis/zend-sf-di-config": "^0.3",
         "mikey179/vfsstream": "^1.6.5",

--- a/src/App/src/Handler/HomePageHandler.php
+++ b/src/App/src/Handler/HomePageHandler.php
@@ -68,7 +68,7 @@ class HomePageHandler implements RequestHandlerInterface
                 $data['containerName'] = 'Symfony DI Container';
                 $data['containerDocs'] = 'https://symfony.com/doc/current/service_container.html';
                 break;
-            case 'Zend\PHPDI\Config\ContainerWrapper':
+            case 'Elie\PHPDI\Config\ContainerWrapper':
             case 'DI\Container':
                 $data['containerName'] = 'PHP-DI';
                 $data['containerDocs'] = 'http://php-di.org';

--- a/src/App/src/Handler/HomePageHandler.php
+++ b/src/App/src/Handler/HomePageHandler.php
@@ -68,7 +68,7 @@ class HomePageHandler implements RequestHandlerInterface
                 $data['containerName'] = 'Symfony DI Container';
                 $data['containerDocs'] = 'https://symfony.com/doc/current/service_container.html';
                 break;
-            case 'Zend\DI\Config\ContainerWrapper':
+            case 'Zend\PHPDI\Config\ContainerWrapper':
             case 'DI\Container':
                 $data['containerName'] = 'PHP-DI';
                 $data['containerDocs'] = 'http://php-di.org';

--- a/src/ExpressiveInstaller/Resources/config/container-php-di.php
+++ b/src/ExpressiveInstaller/Resources/config/container-php-di.php
@@ -1,7 +1,7 @@
 <?php
 
-use Zend\PHPDI\Config\Config;
-use Zend\PHPDI\Config\ContainerFactory;
+use Elie\PHPDI\Config\Config;
+use Elie\PHPDI\Config\ContainerFactory;
 
 // Protect variables from global scope
 return call_user_func(function () {

--- a/src/ExpressiveInstaller/Resources/config/container-php-di.php
+++ b/src/ExpressiveInstaller/Resources/config/container-php-di.php
@@ -1,11 +1,14 @@
 <?php
 
-declare(strict_types = 1);
+use Zend\PHPDI\Config\Config;
+use Zend\PHPDI\Config\ContainerFactory;
 
-use Zend\DI\Config\Config;
-use Zend\DI\Config\ContainerFactory;
+// Protect variables from global scope
+return call_user_func(function () {
 
-$config  = require __DIR__ . '/config.php';
-$factory = new ContainerFactory();
+    $config = require __DIR__ . '/config.php';
 
-return $factory(new Config($config));
+    $factory = new ContainerFactory();
+
+    return $factory(new Config($config));
+});

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 return [
     'packages' => [
         'elie29/zend-phpdi-config' => [
-            'version' => '^3.0',
+            'version' => '^4.0',
         ],
         'filp/whoops' => [
             'version' => '^2.1.12',


### PR DESCRIPTION
@xtreamwayz suggested a namespace change for [zend-di-config](https://github.com/elie29/zend-di-config) [#31](https://github.com/elie29/zend-di-config/issues/31). 

Starting from v4, the namespace will be Elie\PHPDI\Config instead of Zend\DI\Config.

A migration document from v3 to v4 has been created [here](https://github.com/elie29/zend-di-config/blob/master/docs/migration-4.0.md) 

