### PR TITLE
Bump zend-servicemanager to ^3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "zendframework/zend-expressive-zendrouter": "^3.0",
         "zendframework/zend-expressive-zendviewrenderer": "^2.0.2",
         "zendframework/zend-pimple-config": "^1.0",
-        "zendframework/zend-servicemanager": "^3.3",
+        "zendframework/zend-servicemanager": "^3.4",
         "zfcampus/zf-development-mode": "^3.1"
     },
     "autoload": {

--- a/src/ExpressiveInstaller/config.php
+++ b/src/ExpressiveInstaller/config.php
@@ -59,7 +59,7 @@ return [
             'version' => '^1.0',
         ],
         'zendframework/zend-servicemanager' => [
-            'version' => '^3.3',
+            'version' => '^3.4',
         ],
     ],
 


### PR DESCRIPTION
zend-servicemanager 3.4.0 enabled plugin managers to accept psr containers not implementing interop interface as a creation context.

This PR bumps used version to ^3.4 to ensure zend-view works with different containers.